### PR TITLE
Providing setting to reduce verbosity of logging

### DIFF
--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
@@ -102,7 +102,7 @@ public class TronUSDtListener(
                         var lastBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync();
                         if (lastBlockNumber > listenerState.LastBlockHeight)
                         {
-                            logger.LogInformation("New block avoid from {BlockNumber} to {NewBlockNumber}",
+                            logger.LogDebug("New block avoid from {BlockNumber} to {NewBlockNumber}",
                                 listenerState.LastBlockHeight, lastBlockNumber);
                             listenerState.LastBlockHeight = lastBlockNumber;
                         }


### PR DESCRIPTION
Resolves: #17

While testing the plugin on one of my instances, I noticed that the logs often fill up with repetitive New block avoid from messages. These are certainly useful for debugging, but they can make it harder for end users to focus on other, more relevant log entries.

<img width="647" height="866" alt="image" src="https://github.com/user-attachments/assets/6e4f86a8-ba86-45f7-9a75-1082890c4872" />

This PR introduces a configuration option to disable those messages when the plugin is not actively being used, helping keep logs cleaner and easier to navigate.