### PR TITLE
Add option to exclude amount from QR code payment link

### DIFF
--- a/BTCPayServer.Plugins.USDt/Controllers/ViewModels/EditTronUSDtPaymentMethodViewModel.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/ViewModels/EditTronUSDtPaymentMethodViewModel.cs
@@ -8,6 +8,7 @@ public class EditTronUSDtPaymentMethodViewModel
     [TronBase58]
     public string? Address { get; init; }
     public bool Enabled { get; init; }
+    public bool ExcludeAmountFromPaymentLink { get; init; }
 
     public EditTronUSDtPaymentMethodAddressViewModel[] Addresses { get; init; } =
         [];

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikeOnChainPaymentMethodDetails.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikeOnChainPaymentMethodDetails.cs
@@ -2,4 +2,5 @@ namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
 public class TronUSDtLikeOnChainPaymentMethodDetails
 {
+    public bool ExcludeAmountFromPaymentLink { get; set; }
 }

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikePaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikePaymentMethodHandler.cs
@@ -34,8 +34,12 @@ public class TronUSDtLikePaymentMethodHandler(
         if (!tronUSDtRpcProvider.IsAvailable(configurationItem.GetPaymentMethodId()))
             throw new PaymentMethodUnavailableException("Node or wallet not available");
 
-        var details = new TronUSDtLikeOnChainPaymentMethodDetails();
-        var availableAddress = await ParsePaymentMethodConfig(context.PaymentMethodConfig)
+        var config = ParsePaymentMethodConfig(context.PaymentMethodConfig);
+        var details = new TronUSDtLikeOnChainPaymentMethodDetails
+        {
+            ExcludeAmountFromPaymentLink = config.ExcludeAmountFromPaymentLink
+        };
+        var availableAddress = await config
                                    .GetOneNotReservedAddress(context.PaymentMethodId, invoiceRepository) ??
                                throw new PaymentMethodUnavailableException("All your TRON addresses are currently waiting payment");
         context.Prompt.Destination = availableAddress;

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using BTCPayServer.Payments;
 using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
@@ -11,6 +12,13 @@ public class TronUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId) : IPa
 
     public string? GetPaymentLink(PaymentPrompt prompt, IUrlHelper? urlHelper)
     {
+        var excludeAmount = prompt.Details?.Value<bool?>("ExcludeAmountFromPaymentLink") ?? false;
+        
+        if (excludeAmount)
+        {
+            return prompt.Destination;
+        }
+        
         var due = prompt.Calculate().Due;
         return $"{prompt.Destination}?amount={due.ToString(CultureInfo.InvariantCulture)}";
     }

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentMethodConfig.cs
@@ -8,6 +8,7 @@ namespace BTCPayServer.Plugins.USDt.Services.Payments;
 public class TronUSDtPaymentMethodConfig
 {
     public string[] Addresses { get; set; } = [];
+    public bool ExcludeAmountFromPaymentLink { get; set; }
 
     public async Task<string?> GetOneNotReservedAddress(PaymentMethodId paymentMethodId,
         InvoiceRepository invoiceRepository)

--- a/BTCPayServer.Plugins.USDt/Views/UITronUSDtLikeStore/GetStoreTronUSDtLikePaymentMethod.cshtml
+++ b/BTCPayServer.Plugins.USDt/Views/UITronUSDtLikeStore/GetStoreTronUSDtLikePaymentMethod.cshtml
@@ -127,6 +127,14 @@
                 <label asp-for="Enabled" class="form-check-label"></label>
                 <span asp-validation-for="Enabled" class="text-danger"></span>
             </div>
+            <div class="d-flex mb-3">
+                <input asp-for="ExcludeAmountFromPaymentLink" type="checkbox" class="btcpay-toggle me-3"/>
+                <label asp-for="ExcludeAmountFromPaymentLink" class="form-check-label">Exclude amount from QR code</label>
+                <span asp-validation-for="ExcludeAmountFromPaymentLink" class="text-danger"></span>
+            </div>
+            <div class="form-text mb-3">
+                Enable this option if your customers use wallets that don't support the amount parameter in the payment link. The QR code will only contain the destination address, and the customer will need to enter the amount manually.
+            </div>
             <div class="form-group">
                 <button type="submit" class="btn btn-primary" id="SaveButton">Save</button>
             </div>


### PR DESCRIPTION
Some wallets don't support the amount parameter in the payment link format. This adds a store-level setting 'Exclude amount from QR code' that, when enabled, generates QR codes containing only the destination address instead of the full payment link with amount parameter.

Fixes compatibility with wallets that don't support the ?amount= query parameter.

Related to #18 