### PR TITLE
fix(tron): add missing tron: URI scheme prefix to TRC20 payment links

### DIFF
--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
@@ -24,8 +24,8 @@ public class TronUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId) : IPa
             return null;
 
         if (excludeAmount)
-            return destination;
+            return $"tron:{destination}";
 
-        return $"{destination}?amount={due.ToString(CultureInfo.InvariantCulture)}";
+        return $"tron:{destination}?amount={due.ToString(CultureInfo.InvariantCulture)}";
     }
 }


### PR DESCRIPTION
## Summary

Adds the missing `tron:` URI scheme prefix to TRC20 payment links generated by `TronUSDtPaymentLinkExtension`, following [TIP-17](https://github.com/tronprotocol/tips/blob/master/tip-17.md) (TRON Payment URI Scheme).

## Problem

Currently, the TRC20 QR code content is:

TCFRHbx7ryg2Hcxx6tbyZT5bhvWTZtsX?amount=100.00


Without the `tron:` prefix, TRON wallets (TronLink, Trust Wallet, etc.) cannot parse the payment link when scanning the QR code. The wallet does not recognize it as a TRON transfer and shows no action.

## Fix

Prepend `tron:` to the payment link in both code branches of `BuildPaymentLink`:

- **excludeAmount branch**: `destination` → `tron:{destination}`
- **main branch**: `{destination}?amount=...` → `tron:{destination}?amount=...`

After fix, QR code content becomes:

tron:TCFRHbx7ryg2Hcxx6tbyZT5bhvWTZtsX?amount=100.00


## Consistency

The EVM implementation (`EVMUSDtPaymentLinkExtension.cs`) already correctly uses the `ethereum:` prefix per EIP-681. This PR brings the TRC20 implementation to the same standard per TIP-17.

## Testing

- [x] Manual verification: `strings` on compiled DLL confirms `tron:` prefix present
- [x] Before fix: QR scan → wallet shows no action
- [ ] After fix: QR scan → wallet prompts transfer confirmation (pending source compile)

## Related Issue

Closes #(issue_number_you_created_above)