### PR TITLE
Bump BTCPay Server to 2.4.0

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.csproj
+++ b/BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
 
         <IsPackable>false</IsPackable>
 

--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -5,7 +5,6 @@ using BTCPayServer.Plugins.USDt.Services.Payments;
 using BTCPayServer.Tests;
 using BTCPayServer.Client.Models;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace BTCPayServer.Plugins.USDt.Tests;
 

--- a/BTCPayServer.Plugins.USDt/BTCPayServer.Plugins.USDt.csproj
+++ b/BTCPayServer.Plugins.USDt/BTCPayServer.Plugins.USDt.csproj
@@ -47,7 +47,6 @@
         <PackageReference Include="Nethereum.RPC" Version="6.1.0"/>
         <PackageReference Include="Nethereum.StandardTokenEIP20" Version="6.1.0"/>
         <PackageReference Include="Nethereum.Web3" Version="6.1.0"/>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     
     </ItemGroup>
 


### PR DESCRIPTION
I don't think there is a need of releasing a new version, those are just compile-time breaking change.
