### PR TITLE
[codex] Gate USDt listeners by store activation

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -1,9 +1,14 @@
 using System.Numerics;
+using System.Security.Claims;
+using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Services;
 using BTCPayServer.Plugins.USDt.Configuration.EVM;
+using BTCPayServer.Plugins.USDt.Configuration.Tron;
 using BTCPayServer.Plugins.USDt.Services.Payments;
 using BTCPayServer.Tests;
 using BTCPayServer.Client.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -179,6 +184,100 @@ public class FastTests : UnitTestBase
     }
 
     [Fact]
+    public void UsdtPaymentMethodConfigDoesNotActivateExcludedEmptyConfigs()
+    {
+        var config = new USDtPaymentMethodConfig();
+
+        Assert.False(config.ActivatesChain(true));
+        Assert.False(USDtChainActivationService.IsActivated(null, false));
+    }
+
+    [Fact]
+    public void UsdtPaymentMethodConfigActivatesLegacyEnabledConfigs()
+    {
+        var config = new USDtPaymentMethodConfig();
+
+        Assert.True(config.ActivatesChain(false));
+    }
+
+    [Fact]
+    public void UsdtPaymentMethodConfigActivatesLegacyConfigsWithAddresses()
+    {
+        var config = new USDtPaymentMethodConfig
+        {
+            Addresses = ["TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL"]
+        };
+
+        Assert.True(config.ActivatesChain(true));
+    }
+
+    [Fact]
+    public void UsdtPaymentMethodConfigKeepsChainActivatedAfterAddressesAreRemoved()
+    {
+        var config = new USDtPaymentMethodConfig
+        {
+            Addresses = ["TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL"]
+        };
+
+        config.MarkActivated();
+        config.Addresses = [];
+
+        Assert.True(config.ActivatesChain(true));
+    }
+
+    [Fact]
+    public void UsdtPaymentMethodConfigPreservesActivationFromPreviousAddresses()
+    {
+        var previousConfig = new USDtPaymentMethodConfig
+        {
+            Addresses = ["TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL"]
+        };
+        var config = new USDtPaymentMethodConfig();
+
+        config.PreserveActivationFrom(previousConfig);
+
+        Assert.True(config.Activated);
+        Assert.True(config.ActivatesChain(true));
+    }
+
+    [Fact]
+    public async Task EvmHandlerPreservesActivationWhenGreenfieldUpdateRemovesLastAddress()
+    {
+        var handler = new EVMUSDtPaymentMethodHandler(CreateEvmConfiguration(), null!, null!, null!);
+        var previousConfig = JObject.FromObject(new EVMUSDtPaymentMethodConfig
+        {
+            Addresses = ["0x742d35cc6634c0532925a3b844bc454e4438f44e"]
+        }, handler.Serializer);
+        var incomingConfig = JObject.FromObject(new EVMUSDtPaymentMethodConfig(), handler.Serializer);
+        var context = CreateValidationContext(incomingConfig, previousConfig);
+
+        await handler.ValidatePaymentMethodConfig(context);
+
+        var parsedConfig =
+            Assert.IsType<EVMUSDtPaymentMethodConfig>(((IPaymentMethodHandler)handler).ParsePaymentMethodConfig(context.Config));
+        Assert.True(parsedConfig.Activated);
+        Assert.Empty(parsedConfig.Addresses);
+    }
+
+    [Fact]
+    public async Task TronHandlerMarksIncomingAddressConfigsActivated()
+    {
+        var handler = new TronUSDtLikePaymentMethodHandler(CreateTronConfiguration(), null!, null!, null!);
+        var incomingConfig = JObject.FromObject(new TronUSDtPaymentMethodConfig
+        {
+            Addresses = ["TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL"]
+        }, handler.Serializer);
+        var context = CreateValidationContext(incomingConfig);
+
+        await handler.ValidatePaymentMethodConfig(context);
+
+        var parsedConfig =
+            Assert.IsType<TronUSDtPaymentMethodConfig>(((IPaymentMethodHandler)handler).ParsePaymentMethodConfig(context.Config));
+        Assert.True(parsedConfig.Activated);
+        Assert.Equal(["TNPeeaaFB7K9cmo4uQpcU32zGK8G1NYqeL"], parsedConfig.Addresses);
+    }
+
+    [Fact]
     public void EvmListenerBatchesDestinationFiltersToReduceRpcFanOut()
     {
         var destinationKeys = Enumerable.Range(0, 45)
@@ -279,7 +378,7 @@ public class FastTests : UnitTestBase
     private sealed class TestableEvmListener : EVMUSDtListener
     {
         public TestableEvmListener()
-            : base(null!, null!, null!, null!, null!, null!, null!, null!)
+            : base(null!, null!, null!, null!, null!, null!, null!, null!, null!)
         {
         }
 
@@ -287,5 +386,48 @@ public class FastTests : UnitTestBase
         {
             return new TestableEvmListener().GetHeadLagBlocks(configuration);
         }
+    }
+
+    private static PaymentMethodConfigValidationContext CreateValidationContext(JToken config, JToken? previousConfig = null)
+    {
+        return new PaymentMethodConfigValidationContext(
+            null!,
+            new ModelStateDictionary(),
+            config,
+            new ClaimsPrincipal(),
+            previousConfig);
+    }
+
+    private static EVMUSDtLikeConfigurationItem CreateEvmConfiguration()
+    {
+        return new EVMUSDtLikeConfigurationItem("ETHEREUM")
+        {
+            JsonRpcUri = new Uri("https://example.com"),
+            SmartContractAddress = "0x1234567890123456789012345678901234567890",
+            Currency = "USDt",
+            DisplayName = "USDt on ETHEREUM",
+            Divisibility = 6,
+            CryptoImagePath = "icon",
+            BlockExplorerLink = "https://example.com/tx/{0}",
+            DefaultRateRules = [],
+            CurrencyDisplayName = "USD₮",
+            ChainId = 1
+        };
+    }
+
+    private static TronUSDtLikeConfigurationItem CreateTronConfiguration()
+    {
+        return new TronUSDtLikeConfigurationItem
+        {
+            JsonRpcUri = new Uri("https://example.com"),
+            SmartContractAddress = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            Currency = "USDt",
+            DisplayName = "USDt on TRON",
+            Divisibility = 6,
+            CryptoImagePath = "icon",
+            BlockExplorerLink = "https://example.com/tx/{0}",
+            DefaultRateRules = [],
+            CurrencyDisplayName = "USD₮"
+        };
     }
 }

--- a/BTCPayServer.Plugins.USDt/Configuration/USDtConfigurationProvider.cs
+++ b/BTCPayServer.Plugins.USDt/Configuration/USDtConfigurationProvider.cs
@@ -222,7 +222,7 @@ public static class USDtConfigurationProvider
                 ],
                 Divisibility = 6,
                 SmartContractAddress = "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
-                JsonRpcUri = new Uri("https://polygon-rpc.com"),
+                JsonRpcUri = new Uri("https://polygon.drpc.org"),
                 BlockExplorerLink = "https://polygonscan.com/tx/{0}",
                 BlockTimeSeconds = 2.0,
                 ChainId = 137
@@ -240,7 +240,7 @@ public static class USDtConfigurationProvider
                 ],
                 Divisibility = 6,
                 SmartContractAddress = "0x0000000000000000000000000000000000000000",
-                JsonRpcUri = new Uri("https://rpc-amoy.polygon.technology/"),
+                JsonRpcUri = new Uri("https://polygon-amoy.drpc.org"),
                 BlockExplorerLink = "https://amoy.polygonscan.com/tx/{0}",
                 BlockTimeSeconds = 2.0,
                 ChainId = 80002

--- a/BTCPayServer.Plugins.USDt/Controllers/UIEVMUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/UIEVMUSDtLikeStoreController.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Configuration;
 using BTCPayServer.Plugins.USDt.Controllers.ViewModels;
 using BTCPayServer.Plugins.USDt.Services;
+using BTCPayServer.Plugins.USDt.Services.Events;
 using BTCPayServer.Plugins.USDt.Services.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
@@ -29,7 +30,8 @@ public class UIEVMUSDtLikeStoreController(
     PaymentMethodHandlerDictionary handlers,
     InvoiceRepository invoiceRepository,
     DisplayFormatter displayFormatter,
-    USDtPluginConfiguration pluginConfiguration) : Controller
+    USDtPluginConfiguration pluginConfiguration,
+    EventAggregator eventAggregator) : Controller
 {
     private StoreData StoreData => HttpContext.GetStoreData();
 
@@ -115,10 +117,12 @@ public class UIEVMUSDtLikeStoreController(
             StoreData.GetPaymentMethodConfig<EVMUSDtPaymentMethodConfig>(paymentMethodId, handlers);
         if (currentPaymentMethodConfig is null) return NotFound();
 
+        currentPaymentMethodConfig.MarkActivated();
         currentPaymentMethodConfig.Addresses = currentPaymentMethodConfig.Addresses.Except(new[] { address }).ToArray();
         StoreData.SetPaymentMethodConfig(handlers[paymentMethodId], currentPaymentMethodConfig);
         store.SetStoreBlob(blob);
         await storeRepository.UpdateStore(store);
+        eventAggregator.Publish(new USDtSettingsChanged());
 
         TempData.SetStatusMessageModel(new StatusMessageModel
         {
@@ -165,6 +169,7 @@ public class UIEVMUSDtLikeStoreController(
                 .. currentPaymentMethodConfig.Addresses,
                 .. addresses
             ];
+            currentPaymentMethodConfig.MarkActivated();
 
             if (addresses.Length == 1)
             {
@@ -183,20 +188,27 @@ public class UIEVMUSDtLikeStoreController(
                 });
             }
         }
-        else if (viewModel.Enabled == blob.IsExcluded(paymentMethodId))
+        else
         {
-            blob.SetExcluded(paymentMethodId, !viewModel.Enabled);
+            if (viewModel.Enabled)
+                currentPaymentMethodConfig.MarkActivated();
 
-            TempData.SetStatusMessageModel(new StatusMessageModel
+            if (viewModel.Enabled == blob.IsExcluded(paymentMethodId))
             {
-                Message = $"{paymentMethodId} is now {(viewModel.Enabled ? "enabled" : "disabled")}",
-                Severity = StatusMessageModel.StatusSeverity.Success
-            });
+                blob.SetExcluded(paymentMethodId, !viewModel.Enabled);
+
+                TempData.SetStatusMessageModel(new StatusMessageModel
+                {
+                    Message = $"{paymentMethodId} is now {(viewModel.Enabled ? "enabled" : "disabled")}",
+                    Severity = StatusMessageModel.StatusSeverity.Success
+                });
+            }
         }
 
         StoreData.SetPaymentMethodConfig(handlers[paymentMethodId], currentPaymentMethodConfig);
         store.SetStoreBlob(blob);
         await storeRepository.UpdateStore(store);
+        eventAggregator.Publish(new USDtSettingsChanged());
 
         return RedirectToAction(nameof(GetStoreEVMUSDtLikePaymentMethod), new { storeId = store.Id, paymentMethodId });
     }

--- a/BTCPayServer.Plugins.USDt/Controllers/UITronUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/UITronUSDtLikeStoreController.cs
@@ -12,6 +12,7 @@ using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Configuration;
 using BTCPayServer.Plugins.USDt.Controllers.ViewModels;
 using BTCPayServer.Plugins.USDt.Services;
+using BTCPayServer.Plugins.USDt.Services.Events;
 using BTCPayServer.Plugins.USDt.Services.Payments;
 using BTCPayServer.Services;
 using BTCPayServer.Services.Invoices;
@@ -30,7 +31,8 @@ public class UITronUSDtLikeStoreController(
     PaymentMethodHandlerDictionary handlers,
     InvoiceRepository invoiceRepository,
     DisplayFormatter displayFormatter,
-    USDtPluginConfiguration pluginConfiguration) : Controller
+    USDtPluginConfiguration pluginConfiguration,
+    EventAggregator eventAggregator) : Controller
 {
     private StoreData StoreData => HttpContext.GetStoreData();
 
@@ -115,10 +117,12 @@ public class UITronUSDtLikeStoreController(
             StoreData.GetPaymentMethodConfig<TronUSDtPaymentMethodConfig>(paymentMethodId, handlers);
         if (currentPaymentMethodConfig is null) return NotFound();
 
+        currentPaymentMethodConfig.MarkActivated();
         currentPaymentMethodConfig.Addresses = currentPaymentMethodConfig.Addresses.Except(new[] { address }).ToArray();
         StoreData.SetPaymentMethodConfig(handlers[paymentMethodId], currentPaymentMethodConfig);
         store.SetStoreBlob(blob);
         await storeRepository.UpdateStore(store);
+        eventAggregator.Publish(new USDtSettingsChanged());
 
         TempData.SetStatusMessageModel(new StatusMessageModel
         {
@@ -165,6 +169,7 @@ public class UITronUSDtLikeStoreController(
                 .. currentPaymentMethodConfig.Addresses,
                 .. addresses
             ];
+            currentPaymentMethodConfig.MarkActivated();
 
 
             if (addresses.Length == 1)
@@ -188,6 +193,8 @@ public class UITronUSDtLikeStoreController(
         {
             // This is the "Save" form submission (not the "Add address" form)
             var messages = new List<string>();
+            if (viewModel.Enabled)
+                currentPaymentMethodConfig.MarkActivated();
 
             if (viewModel.Enabled == blob.IsExcluded(paymentMethodId))
             {
@@ -217,6 +224,7 @@ public class UITronUSDtLikeStoreController(
         StoreData.SetPaymentMethodConfig(handlers[paymentMethodId], currentPaymentMethodConfig);
         store.SetStoreBlob(blob);
         await storeRepository.UpdateStore(store);
+        eventAggregator.Publish(new USDtSettingsChanged());
 
 
         return RedirectToAction("GetStoreTronUSDtLikePaymentMethod", new { storeId = store.Id, paymentMethodId });

--- a/BTCPayServer.Plugins.USDt/Services/EVMUSDtLikeSummaryUpdaterHostedService.cs
+++ b/BTCPayServer.Plugins.USDt/Services/EVMUSDtLikeSummaryUpdaterHostedService.cs
@@ -9,8 +9,9 @@ namespace BTCPayServer.Plugins.USDt.Services;
 public class EVMUSDtLikeSummaryUpdaterHostedService(
     EVMUSDtRPCProvider rpcProvider,
     USDtPluginConfiguration usdtPluginConfiguration,
-    Logs logs)
-    : USDtSummaryUpdaterHostedService(logs)
+    Logs logs,
+    USDtChainActivationService activationService)
+    : USDtSummaryUpdaterHostedService(logs, activationService)
 {
     protected override IEnumerable<PaymentMethodId> GetPaymentMethodIds()
     {

--- a/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
@@ -26,6 +26,7 @@ public class EVMUSDtListener(
     EventAggregator eventAggregator,
     EVMUSDtRPCProvider rpcProvider,
     USDtPluginConfiguration usdtPluginConfiguration,
+    USDtChainActivationService activationService,
     ILogger<EVMUSDtListener> logger,
     PaymentMethodHandlerDictionary handlers,
     PaymentService paymentService)
@@ -34,6 +35,7 @@ public class EVMUSDtListener(
         settingsRepository,
         eventAggregator,
         rpcProvider,
+        activationService,
         logger,
         handlers,
         paymentService)

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodHandler.cs
@@ -68,6 +68,17 @@ public class EVMUSDtPaymentMethodHandler(
                throw new FormatException($"Invalid {nameof(EVMUSDtPaymentMethodHandler)}");
     }
 
+    public Task ValidatePaymentMethodConfig(PaymentMethodConfigValidationContext validationContext)
+    {
+        var config = ParsePaymentMethodConfig(validationContext.Config);
+        var previousConfig = validationContext.PreviousConfig is null
+            ? null
+            : ParsePaymentMethodConfig(validationContext.PreviousConfig);
+        config.PreserveActivationFrom(previousConfig);
+        validationContext.Config = JToken.FromObject(config, Serializer);
+        return Task.CompletedTask;
+    }
+
     public EVMUSDtLikeOnChainPaymentMethodDetails? ParsePaymentPromptDetails(JToken details)
     {
         return details.ToObject<EVMUSDtLikeOnChainPaymentMethodDetails>(Serializer);

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikePaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikePaymentMethodHandler.cs
@@ -68,6 +68,17 @@ public class TronUSDtLikePaymentMethodHandler(
                throw new FormatException($"Invalid {nameof(TronUSDtLikePaymentMethodHandler)}");
     }
 
+    public Task ValidatePaymentMethodConfig(PaymentMethodConfigValidationContext validationContext)
+    {
+        var config = ParsePaymentMethodConfig(validationContext.Config);
+        var previousConfig = validationContext.PreviousConfig is null
+            ? null
+            : ParsePaymentMethodConfig(validationContext.PreviousConfig);
+        config.PreserveActivationFrom(previousConfig);
+        validationContext.Config = JToken.FromObject(config, Serializer);
+        return Task.CompletedTask;
+    }
+
     public TronUSDtLikeOnChainPaymentMethodDetails? ParsePaymentPromptDetails(JToken details)
     {
         return details.ToObject<TronUSDtLikeOnChainPaymentMethodDetails>(Serializer);

--- a/BTCPayServer.Plugins.USDt/Services/Payments/USDtPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/USDtPaymentMethodConfig.cs
@@ -10,6 +10,28 @@ namespace BTCPayServer.Plugins.USDt.Services.Payments;
 public class USDtPaymentMethodConfig
 {
     public string[] Addresses { get; set; } = [];
+    public bool Activated { get; set; }
+
+    public void MarkActivated()
+    {
+        Activated = true;
+    }
+
+    public void PreserveActivationFrom(USDtPaymentMethodConfig? previousConfig)
+    {
+        if (WasConfiguredOrActivated() || previousConfig?.WasConfiguredOrActivated() is true)
+            MarkActivated();
+    }
+
+    public bool ActivatesChain(bool excluded)
+    {
+        return WasConfiguredOrActivated() || !excluded;
+    }
+
+    private bool WasConfiguredOrActivated()
+    {
+        return Activated || Addresses is { Length: > 0 };
+    }
 
     public async Task<string?> GetOneNotReservedAddress(PaymentMethodId paymentMethodId,
         InvoiceRepository invoiceRepository,

--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtLikeSummaryUpdaterHostedService.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtLikeSummaryUpdaterHostedService.cs
@@ -9,8 +9,9 @@ namespace BTCPayServer.Plugins.USDt.Services;
 public class TronUSDtLikeSummaryUpdaterHostedService(
     TronUSDtRPCProvider tronUSDtRpcProvider,
     USDtPluginConfiguration usdtPluginConfiguration,
-    Logs logs)
-    : USDtSummaryUpdaterHostedService(logs)
+    Logs logs,
+    USDtChainActivationService activationService)
+    : USDtSummaryUpdaterHostedService(logs, activationService)
 {
     protected override IEnumerable<PaymentMethodId> GetPaymentMethodIds()
     {

--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
@@ -25,6 +25,7 @@ public class TronUSDtListener(
     EventAggregator eventAggregator,
     TronUSDtRPCProvider tronUSDtRpcProvider,
     USDtPluginConfiguration usdtPluginConfiguration,
+    USDtChainActivationService activationService,
     ILogger<TronUSDtListener> logger,
     PaymentMethodHandlerDictionary handlers,
     PaymentService paymentService)
@@ -33,6 +34,7 @@ public class TronUSDtListener(
         settingsRepository,
         eventAggregator,
         tronUSDtRpcProvider,
+        activationService,
         logger,
         handlers,
         paymentService)

--- a/BTCPayServer.Plugins.USDt/Services/USDtChainActivationService.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtChainActivationService.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer;
+using BTCPayServer.Data;
+using BTCPayServer.Events;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.USDt.Configuration;
+using BTCPayServer.Plugins.USDt.Services.Events;
+using BTCPayServer.Plugins.USDt.Services.Payments;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Stores;
+
+namespace BTCPayServer.Plugins.USDt.Services;
+
+public class USDtChainActivationService : IDisposable
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+    private readonly StoreRepository _storeRepository;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly USDtPluginConfiguration _pluginConfiguration;
+    private readonly IEventAggregatorSubscription[] _eventAggregatorSubscriptions;
+    private readonly object _cacheLock = new();
+    private HashSet<PaymentMethodId>? _activePaymentMethodIds;
+    private DateTimeOffset _cacheExpiresAt;
+    private long _cacheVersion;
+
+    public USDtChainActivationService(
+        StoreRepository storeRepository,
+        PaymentMethodHandlerDictionary handlers,
+        USDtPluginConfiguration pluginConfiguration,
+        EventAggregator eventAggregator)
+    {
+        _storeRepository = storeRepository;
+        _handlers = handlers;
+        _pluginConfiguration = pluginConfiguration;
+        _eventAggregatorSubscriptions =
+        [
+            eventAggregator.Subscribe<USDtSettingsChanged>(_ => Invalidate()),
+            eventAggregator.SubscribeAny<StoreEvent>(_ => Invalidate())
+        ];
+    }
+
+    public async Task<bool> IsActivatedAsync(PaymentMethodId paymentMethodId, CancellationToken cancellationToken)
+    {
+        var activePaymentMethodIds = await GetActivePaymentMethodIds(cancellationToken);
+        return activePaymentMethodIds.Contains(paymentMethodId);
+    }
+
+    public void Invalidate()
+    {
+        lock (_cacheLock)
+        {
+            _cacheVersion++;
+            _activePaymentMethodIds = null;
+            _cacheExpiresAt = DateTimeOffset.MinValue;
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var subscription in _eventAggregatorSubscriptions)
+            subscription.Dispose();
+    }
+
+    private async Task<HashSet<PaymentMethodId>> GetActivePaymentMethodIds(CancellationToken cancellationToken)
+    {
+        long cacheVersion;
+        lock (_cacheLock)
+        {
+            if (_activePaymentMethodIds is not null && _cacheExpiresAt > DateTimeOffset.UtcNow)
+                return [.. _activePaymentMethodIds];
+
+            cacheVersion = _cacheVersion;
+        }
+
+        var activePaymentMethodIds = await LoadActivePaymentMethodIds(cancellationToken);
+        lock (_cacheLock)
+        {
+            if (cacheVersion != _cacheVersion)
+                return activePaymentMethodIds;
+
+            _activePaymentMethodIds = activePaymentMethodIds;
+            _cacheExpiresAt = DateTimeOffset.UtcNow.Add(CacheDuration);
+            return [.. _activePaymentMethodIds];
+        }
+    }
+
+    private async Task<HashSet<PaymentMethodId>> LoadActivePaymentMethodIds(CancellationToken cancellationToken)
+    {
+        var configuredPaymentMethodIds = GetConfiguredPaymentMethodIds().ToHashSet();
+        var activePaymentMethodIds = new HashSet<PaymentMethodId>();
+        if (configuredPaymentMethodIds.Count == 0)
+            return activePaymentMethodIds;
+
+        var stores = await _storeRepository.GetStores();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var store in stores.Where(store => !store.Archived))
+        {
+            var excludedPaymentMethods = store.GetStoreBlob().GetExcludedPaymentMethods();
+            var storeUpdated = false;
+            foreach (var paymentMethodId in configuredPaymentMethodIds)
+            {
+                if (activePaymentMethodIds.Contains(paymentMethodId))
+                    continue;
+
+                var config = store.GetPaymentMethodConfig<USDtPaymentMethodConfig>(paymentMethodId, _handlers);
+                if (!IsActivated(config, excludedPaymentMethods.Match(paymentMethodId)))
+                    continue;
+
+                activePaymentMethodIds.Add(paymentMethodId);
+                if (config is { Activated: false })
+                {
+                    config.MarkActivated();
+                    store.SetPaymentMethodConfig(_handlers[paymentMethodId], config);
+                    storeUpdated = true;
+                }
+            }
+
+            if (storeUpdated)
+            {
+                await _storeRepository.UpdateStore(store);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            if (activePaymentMethodIds.Count == configuredPaymentMethodIds.Count)
+                break;
+        }
+
+        return activePaymentMethodIds;
+    }
+
+    private IEnumerable<PaymentMethodId> GetConfiguredPaymentMethodIds()
+    {
+        return _pluginConfiguration.TronUSDtLikeConfigurationItems.Keys
+            .Concat(_pluginConfiguration.EVMUSDtLikeConfigurationItems.Keys);
+    }
+
+    internal static bool IsActivated(USDtPaymentMethodConfig? config, bool excluded)
+    {
+        return config?.ActivatesChain(excluded) is true;
+    }
+}

--- a/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
@@ -26,6 +26,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
     ISettingsRepository settingsRepository,
     EventAggregator eventAggregator,
     USDtRPCProvider<TConfigurationItem> rpcProvider,
+    USDtChainActivationService activationService,
     ILogger logger,
     PaymentMethodHandlerDictionary handlers,
     PaymentService paymentService) : IHostedService
@@ -87,9 +88,17 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
         while (!stoppingToken.IsCancellationRequested)
             try
             {
-                var listenerState = await LoadTrackingState(configurationItem);
                 using var _ = BeginLoggingScope(paymentMethodId);
+                if (!await activationService.IsActivatedAsync(paymentMethodId, stoppingToken))
+                {
+                    logger.LogDebug(
+                        "Skipping indexing for {Listener}; no store has activated this payment method yet",
+                        logContext);
+                    await Task.Delay(30_000, stoppingToken);
+                    continue;
+                }
 
+                var listenerState = await LoadTrackingState(configurationItem);
                 var web3Client = rpcProvider.GetWeb3Client(paymentMethodId);
                 if (listenerState == null)
                 {
@@ -170,6 +179,9 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                     await SetTrackingState(configurationItem, listenerState);
                     rateLimitBackoffMs = 5_000;
                 }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
             }
             catch (USDtListenerTransientException e)
             {

--- a/BTCPayServer.Plugins.USDt/Services/USDtSummaryUpdaterHostedService.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtSummaryUpdaterHostedService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace BTCPayServer.Plugins.USDt.Services;
 
-public abstract class USDtSummaryUpdaterHostedService(Logs logs) : IHostedService
+public abstract class USDtSummaryUpdaterHostedService(Logs logs, USDtChainActivationService activationService) : IHostedService
 {
     private CancellationTokenSource? _cts;
 
@@ -43,6 +43,12 @@ public abstract class USDtSummaryUpdaterHostedService(Logs logs) : IHostedServic
             {
                 try
                 {
+                    if (!await activationService.IsActivatedAsync(paymentMethodId, cancellation))
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(30), cancellation);
+                        continue;
+                    }
+
                     await UpdateSummary(paymentMethodId);
                     await Task.Delay(IsAvailable(paymentMethodId) ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(30),
                         cancellation);

--- a/BTCPayServer.Plugins.USDt/USDtPlugin.cs
+++ b/BTCPayServer.Plugins.USDt/USDtPlugin.cs
@@ -52,6 +52,7 @@ public class USDtPlugin : BaseBTCPayServerPlugin
         };
 
         services.AddSingleton(pluginConfiguration);
+        services.AddSingleton<USDtChainActivationService>();
         services.AddHostedService<USDtPluginConfigurationBootstrapper>();
 
         services.AddCurrencyData(new CurrencyData


### PR DESCRIPTION
## Summary
- Gate USDt listener and sync summary RPC polling behind a shared store activation check.
- Add sticky activation to USDt store payment configs so chains remain active after addresses are removed.
- Preserve existing installs by treating legacy configs with addresses, or enabled legacy configs, as active.
- Refresh the default Polygon RPC endpoints to Polygon current documented dRPC endpoints.

## Details
Inactive chains now skip listener state initialization and summary probing, so default chains with no store configuration do not call their RPC endpoints. Store actions mark a USDt payment method as activated when addresses are added or when the payment method is saved as enabled; address removal never clears activation.

## Validation
- `DOTNET_ROOT=/tmp/dotnet10 PATH=/tmp/dotnet10:$PATH dotnet test BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.csproj --no-restore`
- `DOTNET_ROOT=/tmp/dotnet10 PATH=/tmp/dotnet10:$PATH dotnet test BTCPayServer.Plugins.USDt.sln` compiled, then failed in upstream BTCPayServer.Tests because local Bitcoin RPC services were unavailable on `127.0.0.1:43782`.
- `git diff --check`
