### PR TITLE
fix(tron): exclude-amount mode emits a bare address so all wallet QR scanners can parse it

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -39,7 +39,7 @@ public class FastTests : UnitTestBase
             12.34m,
             false);
 
-        Assert.Equal("TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34", result);
+        Assert.Equal("tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34", result);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
@@ -23,8 +23,11 @@ public class TronUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId) : IPa
         if (string.IsNullOrEmpty(destination))
             return null;
 
+        // Bare address, no URI scheme: the store setting documents this mode as "the QR
+        // code will only contain the destination address", and QR scanners that reject
+        // tron: URIs (e.g. TronLink's in-Send scanner) only accept a plain base58 address.
         if (excludeAmount)
-            return $"tron:{destination}";
+            return destination;
 
         return $"tron:{destination}?amount={due.ToString(CultureInfo.InvariantCulture)}";
     }


### PR DESCRIPTION
## Problem
The "Exclude amount from QR code" store setting's help text says *"The QR code will only contain the destination address"*, but since #41 the exclude branch still emits `tron:{address}`.

Wallet QR scanners that don't support TIP-17 URIs reject any payload that isn't a plain base58 address. Concretely: TronLink's in-Send scanner fails with **"Incorrect account address format"** on both `tron:ADDR?amount=X` and `tron:ADDR` (real-user report, TronLink iOS, July 2026). A bare address is what exchange deposit pages render and what every TRON wallet accepts.

## Change
- `BuildPaymentLink(..., excludeAmount: true)` returns the bare `destination` — matching the setting's documented behavior and the existing unit test `TronPaymentLinkCanExcludeAmount` (which already expected the bare address).
- Updates `TronPaymentLinkIncludesAmountByDefault` to expect the `tron:` prefix — #41 changed the code but not this test.
- With-amount default behavior is unchanged (TIP-17 URI).

## Notes
- All 8 `*PaymentLink*` tests pass. Heads-up: `dotnet test` in CI currently no-ops because the test csproj only defines `Release;Altcoins-Debug` configurations and the workflow builds the default configuration — which is how the stale test expectation survived #41. Happy to file that separately.
- Verified on a live BTCPay 2.4.0 instance: with the toggle on, invoice `paymentLink` is the bare address and TronLink scans it correctly.