### PR TITLE
feat(evm): allow payment link customization

### DIFF
--- a/BTCPayServer.Plugins.USDt/Controllers/UIEVMUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/UIEVMUSDtLikeStoreController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
@@ -92,6 +93,7 @@ public class UIEVMUSDtLikeStoreController(
             ChainDisplayName = config.Chain,
             Enabled = !excludeFilters.Match(paymentMethodId),
             Address = "",
+            PaymentLinkTemplate = matchedPaymentMethodConfig.PaymentLinkTemplate,
             Addresses = matchedPaymentMethodConfig.Addresses.Select(s =>
                 new EditEVMUSDtPaymentMethodViewModel.EditEVMUSDtPaymentMethodAddressViewModel
                 {
@@ -153,7 +155,7 @@ public class UIEVMUSDtLikeStoreController(
                 .Select(a => a.ToLowerInvariant())
                 .Where(s => currentPaymentMethodConfig.Addresses.Contains(s) == false).ToArray();
 
-            if(addresses.Any() == false)
+            if (addresses.Any() == false)
             {
                 TempData.SetStatusMessageModel(new StatusMessageModel
                 {
@@ -190,6 +192,7 @@ public class UIEVMUSDtLikeStoreController(
         }
         else
         {
+            var messages = new List<string>();
             if (viewModel.Enabled)
                 currentPaymentMethodConfig.MarkActivated();
 
@@ -197,11 +200,13 @@ public class UIEVMUSDtLikeStoreController(
             {
                 blob.SetExcluded(paymentMethodId, !viewModel.Enabled);
 
-                TempData.SetStatusMessageModel(new StatusMessageModel
-                {
-                    Message = $"{paymentMethodId} is now {(viewModel.Enabled ? "enabled" : "disabled")}",
-                    Severity = StatusMessageModel.StatusSeverity.Success
-                });
+                messages.Add($"{paymentMethodId} is now {(viewModel.Enabled ? "enabled" : "disabled")}");
+            }
+
+            if (currentPaymentMethodConfig.PaymentLinkTemplate != viewModel.PaymentLinkTemplate)
+            {
+                currentPaymentMethodConfig.PaymentLinkTemplate = viewModel.PaymentLinkTemplate;
+                messages.Add("Payment link template updated");
             }
         }
 

--- a/BTCPayServer.Plugins.USDt/Controllers/ViewModels/EditEVMUSDtPaymentMethodViewModel.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/ViewModels/EditEVMUSDtPaymentMethodViewModel.cs
@@ -9,6 +9,9 @@ public class EditEVMUSDtPaymentMethodViewModel
     public string AddressPlaceholder { get; init; } = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
     public string? Address { get; init; }
     public bool Enabled { get; init; }
+    public string? PaymentLinkTemplate { get; init; }
+    // available placeholders {smartContractAddress}, {chainId}, {to}, {amountUnits}, {amount}
+    public string PaymentLinkTemplatePlaceholder = "ethereum:{smartContractAddress}@{chainId}/transfer?address={to}&uint256={amountUnits}";
 
     public EditEVMUSDtPaymentMethodAddressViewModel[] Addresses { get; init; } = [];
 

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtLikeOnChainPaymentMethodDetails.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtLikeOnChainPaymentMethodDetails.cs
@@ -2,4 +2,5 @@ namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
 public class EVMUSDtLikeOnChainPaymentMethodDetails
 {
+    public string? PaymentLinkTemplate { get; set; }
 }

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentLinkExtension.cs
@@ -22,7 +22,8 @@ public class EVMUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId, USDtPl
             configuration.SmartContractAddress,
             configuration.ChainId,
             configuration.Divisibility,
-            prompt.Calculate().Due);
+            prompt.Calculate().Due,
+            prompt.Details?.Value<string?>("paymentLinkTemplate") ?? "ethereum:{smartContractAddress}@{chainId}/transfer?address={to}&uint256={amountUnits}");
     }
 
     internal static string? BuildPaymentLink(
@@ -30,7 +31,8 @@ public class EVMUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId, USDtPl
         string smartContractAddress,
         int chainId,
         int divisibility,
-        decimal due)
+        decimal due,
+        string paymentLinkTemplate)
     {
         if (string.IsNullOrEmpty(destination) ||
             string.IsNullOrWhiteSpace(smartContractAddress) ||
@@ -50,6 +52,11 @@ public class EVMUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId, USDtPl
         var amountUnits = BigInteger.Parse(unitsDec.ToString("0", CultureInfo.InvariantCulture));
 
         // EIP-681 ERC-20 transfer link: ethereum:{contract}@{chainId}/transfer?address={to}&uint256={amount}
-        return $"ethereum:{smartContractAddress.ToLowerInvariant()}@{chainId}/transfer?address={to}&uint256={amountUnits}";
+        return paymentLinkTemplate
+            .Replace("{smartContractAddress}", smartContractAddress.ToLowerInvariant())
+            .Replace("{chainId}", chainId.ToString())
+            .Replace("{to}", to)
+            .Replace("{amountUnits}", amountUnits.ToString())
+            .Replace("{amount}", due.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodConfig.cs
@@ -6,6 +6,8 @@ namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
 public class EVMUSDtPaymentMethodConfig : USDtPaymentMethodConfig
 {
+    public string? PaymentLinkTemplate { get; set; }
+
     public async Task<string?> GetOneNotReservedAddress(PaymentMethodId paymentMethodId,
         InvoiceRepository invoiceRepository)
     {

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodHandler.cs
@@ -37,7 +37,11 @@ public class EVMUSDtPaymentMethodHandler(
             throw new PaymentMethodUnavailableException(
                 $"{configurationItem.DisplayName} is not configured with a smart contract address yet");
 
-        var details = new EVMUSDtLikeOnChainPaymentMethodDetails();
+        var config = ParsePaymentMethodConfig(context.PaymentMethodConfig);
+        var details = new EVMUSDtLikeOnChainPaymentMethodDetails()
+        {
+            PaymentLinkTemplate = config.PaymentLinkTemplate
+        };
         var availableAddress = await ParsePaymentMethodConfig(context.PaymentMethodConfig)
                                    .GetOneNotReservedAddress(context.PaymentMethodId, invoiceRepository) ??
                                throw new PaymentMethodUnavailableException(

--- a/BTCPayServer.Plugins.USDt/Views/UIEVMUSDtLikeStore/GetStoreEVMUSDtLikePaymentMethod.cshtml
+++ b/BTCPayServer.Plugins.USDt/Views/UIEVMUSDtLikeStore/GetStoreEVMUSDtLikePaymentMethod.cshtml
@@ -17,127 +17,144 @@
         <div asp-validation-summary="All"></div>
     </div>
 </div>
-<partial name="_StatusMessage"/>
+<partial name="_StatusMessage" />
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <symbol id="check-circle-fill" fill="currentColor" viewBox="0 0 16 16">
-        <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+        <path
+        d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z" />
     </symbol>
     <symbol id="info-fill" fill="currentColor" viewBox="0 0 16 16">
-        <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+        <path
+        d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z" />
     </symbol>
     <symbol id="exclamation-triangle-fill" fill="currentColor" viewBox="0 0 16 16">
-        <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+        <path
+        d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z" />
     </symbol>
 </svg>
 <div class="row">
     <div class="col-md-8">
         <p class="mb-0">
-            Configures the @Model.ChainDisplayName addresses used for payment by your customers. Each address is reserved for the time of payment and settlement, so we advise you to set several addresses.
+            Configures the @Model.ChainDisplayName addresses used for payment by your customers. Each address is
+            reserved for the time of payment and settlement, so we advise you to set several addresses.
         </p>
-        <form method="post"
-              asp-route-storeId="@Context.GetRouteValue("storeId")"
-              asp-route-paymentMethodId="@Context.GetRouteValue("paymentMethodId")"
-              class="mt-4" enctype="multipart/form-data">
+        <form method="post" asp-route-storeId="@Context.GetRouteValue("storeId")"
+              asp-route-paymentMethodId="@Context.GetRouteValue("paymentMethodId")" class="mt-4"
+              enctype="multipart/form-data">
             <div class="d-flex flex-wrap align-items-center gap-3">
-                <input asp-for="Address" type="text" class="form-control" placeholder="@Model.AddressPlaceholder" style="flex: 1 1 14rem">
-                <button type="submit" role="button" class="btn btn-primary text-nowrap flex-grow-1 flex-sm-grow-0">Add address(es)</button>
-            </div>
-            <div class="form-text">
-                You can add multiple addresses separated by a comma or a new line.
-            </div>
-        </form>
-        @if (Model.Addresses.Any())
-        {
-            <table class="table table-hover table-responsive-md">
-                <thead>
-                <tr>
-                    <th>Address</th>
-                    <th>Balance</th>
-                    <th>
-                        <span data-bs-toggle="tooltip" data-bs-placement="top" title="Addresses are attached to pending payments and free after settlement.">Free or used? <vc:icon symbol="info"/></span>
-                    </th>
-                    <th class="actions-col" permission="@Policies.CanModifyStoreSettings">Actions</th>
-                </tr>
-                </thead>
-                <tbody id="StoreUsersList">
-
-                @foreach (var address in Model.Addresses)
-                {
-                    <tr>
-                        <td>@address.Value</td>
-                        <td>@address.Balance</td>
-                        <td class="text-center">
-                            @if (address.Available)
-                            {
-                                <span class="me-2 btcpay-status btcpay-status--enabled"></span>
-                            }
-                            else
-                            {
-                                <span class="me-2 btcpay-status btcpay-status--disabled"></span>
-                            }
-                        </td>
-
-                        <td class="actions-col" permission="@Policies.CanModifyStoreSettings">
-                            <form method="post" asp-action="DeleteAddress"
-                                  asp-route-storeId="@Context.GetRouteValue("storeId")"
-                                  asp-route-paymentMethodId="@Context.GetRouteValue("paymentMethodId")"
-                                  asp-route-address="@address.Value"
-                                  enctype="multipart/form-data">
-                                <input class="btn btn-link p-0" type="submit" value="Remove"/>
-                            </form>
-                        </td>
-                    </tr>
-                }
-                </tbody>
-            </table>
-            if (Model.Addresses.Any(a => a.Balance == "N/A"))
+                <input asp-for="Address" type="text" class="form-control" placeholder="@Model.AddressPlaceholder"
+                       style="flex: 1 1 14rem">
+                <button type="submit" role="button" class="btn btn-primary text-nowrap flex-grow-1 flex-sm-grow-0">Add
+                    address(es)</button>
+                </div>
+                <div class="form-text">
+                    You can add multiple addresses separated by a comma or a new line.
+                </div>
+            </form>
+            @if (Model.Addresses.Any())
             {
-                <div class="alert alert-danger d-flex align-items-center" role="alert">
+                <table class="table table-hover table-responsive-md">
+                    <thead>
+                        <tr>
+                            <th>Address</th>
+                            <th>Balance</th>
+                            <th>
+                                <span data-bs-toggle="tooltip" data-bs-placement="top"
+                                      title="Addresses are attached to pending payments and free after settlement.">Free or used?
+                                    <vc:icon symbol="info" />
+                                </span>
+                            </th>
+                            <th class="actions-col" permission="@Policies.CanModifyStoreSettings">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="StoreUsersList">
+
+                        @foreach (var address in Model.Addresses)
+                        {
+                            <tr>
+                                <td>@address.Value</td>
+                                <td>@address.Balance</td>
+                                <td class="text-center">
+                                    @if (address.Available)
+                                    {
+                                        <span class="me-2 btcpay-status btcpay-status--enabled"></span>
+                                    }
+                                    else
+                                    {
+                                        <span class="me-2 btcpay-status btcpay-status--disabled"></span>
+                                    }
+                                </td>
+
+                                <td class="actions-col" permission="@Policies.CanModifyStoreSettings">
+                                    <form method="post" asp-action="DeleteAddress"
+                                          asp-route-storeId="@Context.GetRouteValue("storeId")"
+                                          asp-route-paymentMethodId="@Context.GetRouteValue("paymentMethodId")"
+                                          asp-route-address="@address.Value" enctype="multipart/form-data">
+                                        <input class="btn btn-link p-0" type="submit" value="Remove" />
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+                if (Model.Addresses.Any(a => a.Balance == "N/A"))
+                {
+                    <div class="alert alert-danger d-flex align-items-center" role="alert">
+                        <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:">
+                            <use xlink:href="#exclamation-triangle-fill" />
+                        </svg>
+                        <div>
+                            Unable to retrieve balances for addresses. Please verify your @Model.ChainDisplayName node connection.
+                        </div>
+                    </div>
+                }
+
+                <div class="alert alert-warning d-flex align-items-center" role="alert">
                     <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:">
-                        <use xlink:href="#exclamation-triangle-fill"/>
+                        <use xlink:href="#exclamation-triangle-fill" />
                     </svg>
                     <div>
-                        Unable to retrieve balances for addresses. Please verify your @Model.ChainDisplayName node connection.
+                        Please avoid using these addresses for any transactions outside this store to ensure proper invoice
+                        matching.
                     </div>
                 </div>
             }
-
-            <div class="alert alert-warning d-flex align-items-center" role="alert">
-                <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:">
-                    <use xlink:href="#exclamation-triangle-fill"/>
-                </svg>
-                <div>
-                    Please avoid using these addresses for any transactions outside this store to ensure proper invoice matching.
+            else
+            {
+                <br />
+                <div class="alert alert-info">
+                    Please add at least one @Model.ChainDisplayName address before using this payment method.
                 </div>
-            </div>
-        }
-        else
-        {
-            <br/>
-            <div class="alert alert-info">
-                Please add at least one @Model.ChainDisplayName address before using this payment method.
-            </div>
-        }
-        <partial name="_Confirm" model="@(new ConfirmModel("Remove address", "This address will no longer be used for incoming payments. Are you sure?", "Delete"))" permission="@Policies.CanModifyStoreSettings"/>
-        <form method="post"
-              asp-route-storeId="@Context.GetRouteValue("storeId")"
-              asp-route-paymentMethodId="@Context.GetRouteValue("paymentMethodId")" class="mt-4" enctype="multipart/form-data">
+            }
+            <partial name="_Confirm"
+                     model="@(new ConfirmModel("Remove address", "This address will no longer be used for incoming payments. Are you sure?", "Delete"))"
+                     permission="@Policies.CanModifyStoreSettings" />
+            <form method="post" asp-route-storeId="@Context.GetRouteValue("storeId")"
+                  asp-route-paymentMethodId="@Context.GetRouteValue("paymentMethodId")" class="mt-4"
+                  enctype="multipart/form-data">
 
-            <div class="d-flex mb-3">
-                <input asp-for="Enabled" type="checkbox" class="btcpay-toggle me-3"/>
-                <label asp-for="Enabled" class="form-check-label"></label>
-                <span asp-validation-for="Enabled" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <button type="submit" class="btn btn-primary" id="SaveButton">Save</button>
-            </div>
-        </form>
+                <div class="d-flex mb-3">
+                    <input asp-for="Enabled" type="checkbox" class="btcpay-toggle me-3" />
+                    <label asp-for="Enabled" class="form-check-label"></label>
+                    <span asp-validation-for="Enabled" class="text-danger"></span>
+                </div>
+                <div class="d-flex mb-3">
+                    <input asp-for="PaymentLinkTemplate" type="text" class="form-control"
+                           placeholder="@Model.PaymentLinkTemplatePlaceholder" style="flex: 1 1 14rem">
+                </div>
+                <div class="form-text mb-3">
+                    Customize payment link template
+                </div>
+                <div class="form-group">
+                    <button type="submit" class="btn btn-primary" id="SaveButton">Save</button>
+                </div>
+            </form>
+        </div>
     </div>
-</div>
 
 
-@* ReSharper disable once Razor.SectionNotResolved *@
+    @* ReSharper disable once Razor.SectionNotResolved *@
 
-@section PageFootContent {
-    @await Html.PartialAsync("_ValidationScriptsPartial")
-}
+    @section PageFootContent {
+        @await Html.PartialAsync("_ValidationScriptsPartial")
+    }


### PR DESCRIPTION
Hello. First of all I would like to say thanks for this awesome plugin!

Looking through issues I see requests like #18, #40 or PR like #46 
I faced issues as well, but with EVM based payment link. For reference, both `SafePal` and `CoinEx wallet` does not support `EIP-681`, and some other wallets too I guess.

My proposal is to make payment link fully configurable from `Store UI`

This is how it looks:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/abc46df4-f7b3-4571-b88e-3aa0b2577421" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/c0129088-b335-4516-8ebf-185f1780049a" width="380"></td>
  </tr>
</table>

This is `EVM` only feature, however I think it might be useful for `Tron` aswell.
I tested this on my `btcpay` instance but still not sure if I did everything in right way. Please let me know if I need to change something.