### PR TITLE
Fix duplicate TRON addresses crashing store settings

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Security.Claims;
 using BTCPayServer.Payments;
+using BTCPayServer.Plugins.USDt.Controllers;
 using BTCPayServer.Plugins.USDt.Services;
 using BTCPayServer.Plugins.USDt.Configuration.EVM;
 using BTCPayServer.Plugins.USDt.Configuration.Tron;
@@ -29,6 +30,33 @@ public class FastTests : UnitTestBase
         Assert.True(TronUSDtAddressHelper.IsValid("TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs"));
         Assert.False(TronUSDtAddressHelper.IsValid("TG2XXyExBkPp9nzdajDZsozEu4BkaSJozs"));
         Assert.False(TronUSDtAddressHelper.IsValid("TG3xXyExBkPp9nzdajDZsozEu4BkaSJozs"));
+    }
+
+    [Fact]
+    public void TronStoreSettingsDetectDuplicateSubmittedAddresses()
+    {
+        var duplicate = UITronUSDtLikeStoreController.FindDuplicateAddress(
+        [
+            "TQQvC5DuajPSPnDN9UA535Ts4tC1uCJUvJ",
+            "TMsbHFUiGrAw13HTqkPekgrseXogWioQ3d",
+            "TMsbHFUiGrAw13HTqkPekgrseXogWioQ3d"
+        ]);
+
+        Assert.Equal("TMsbHFUiGrAw13HTqkPekgrseXogWioQ3d", duplicate);
+    }
+
+    [Fact]
+    public void TronStoreSettingsUsesFirstBalanceForLegacyDuplicates()
+    {
+        const string address = "TMsbHFUiGrAw13HTqkPekgrseXogWioQ3d";
+
+        var balance = UITronUSDtLikeStoreController.FindBalance(
+        [
+            (address, 10m),
+            (address, 20m)
+        ], address);
+
+        Assert.Equal(10m, balance);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.USDt/Controllers/UITronUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/UITronUSDtLikeStoreController.cs
@@ -82,8 +82,10 @@ public class UITronUSDtLikeStoreController(
                 Enabled = false
             });
 
-        var balances =
-            await tronUSDtRpcProvider.GetBalances(paymentMethodId, [.. matchedPaymentMethodConfig.Addresses]);
+        var addresses = matchedPaymentMethodConfig.Addresses
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var balances = await tronUSDtRpcProvider.GetBalances(paymentMethodId, addresses);
         var reservedAddresses =
             await TronUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, invoiceRepository);
 
@@ -92,16 +94,32 @@ public class UITronUSDtLikeStoreController(
             Enabled = !excludeFilters.Match(paymentMethodId),
             Address = "",
             ExcludeAmountFromPaymentLink = matchedPaymentMethodConfig.ExcludeAmountFromPaymentLink,
-            Addresses = matchedPaymentMethodConfig.Addresses.Select(s =>
-                new EditTronUSDtPaymentMethodViewModel.EditTronUSDtPaymentMethodAddressViewModel
+            Addresses = addresses.Select(s =>
+            {
+                var balance = FindBalance(balances, s);
+                return new EditTronUSDtPaymentMethodViewModel.EditTronUSDtPaymentMethodAddressViewModel
                 {
                     Available = reservedAddresses.Contains(s) == false,
-                    Balance = balances.Single(x => x.Item1 == s).Item2 == null
+                    Balance = balance == null
                         ? "N/A"
-                        : displayFormatter.Currency(balances.Single(x => x.Item1 == s).Item2!.Value, "USD\u20ae"),
+                        : displayFormatter.Currency(balance.Value, "USD\u20ae"),
                     Value = s
-                }).ToArray()
+                };
+            }).ToArray()
         });
+    }
+
+    internal static decimal? FindBalance(IEnumerable<(string Address, decimal? Balance)> balances, string address)
+    {
+        return balances.FirstOrDefault(balance => balance.Address == address).Balance;
+    }
+
+    internal static string? FindDuplicateAddress(IEnumerable<string> addresses)
+    {
+        return addresses
+            .GroupBy(address => address, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Skip(1).Any())?
+            .Key;
     }
 
     [HttpPost("{paymentMethodId}/addresses/{address}/delete")]
@@ -149,9 +167,26 @@ public class UITronUSDtLikeStoreController(
 
         if (string.IsNullOrEmpty(viewModel.Address) == false)
         {
-            var addresses = viewModel.Address.Split(new char[] { ',', ';', ' ', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            var submittedAddresses = viewModel.Address
+                .Split(new char[] { ',', ';', ' ', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(TronUSDtAddressHelper.IsValid)
-                .Where(s => currentPaymentMethodConfig.Addresses.Contains(s) == false).ToArray();
+                .ToArray();
+            var duplicateAddress = FindDuplicateAddress(submittedAddresses);
+
+            if (duplicateAddress is not null)
+            {
+                TempData.SetStatusMessageModel(new StatusMessageModel
+                {
+                    Message = $"Duplicate address: {duplicateAddress}. Remove duplicate entries and try again.",
+                    Severity = StatusMessageModel.StatusSeverity.Error
+                });
+
+                return RedirectToAction("GetStoreTronUSDtLikePaymentMethod", new { storeId = store.Id, paymentMethodId });
+            }
+
+            var addresses = submittedAddresses
+                .Where(s => currentPaymentMethodConfig.Addresses.Contains(s) == false)
+                .ToArray();
             
             if(addresses.Any() == false)
             {


### PR DESCRIPTION
## Summary

- reject duplicate TRON addresses in a submission with a clear error
- deduplicate legacy stored addresses before balance retrieval and display
- replace the throwing `Single()` balance lookup with a safe first-match lookup
- add regression tests for duplicate detection and legacy duplicate balance results

Closes #51

## Testing

- `dotnet run --project BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.csproj --configuration Release --no-restore -- -noColor -method "*TronStoreSettingsDetectDuplicateSubmittedAddresses" -method "*TronStoreSettingsUsesFirstBalanceForLegacyDuplicates"` (2 passed)
- Full xUnit runner: 25/27 passed; the two failures are existing `TronPaymentLink*` assertions on `master` that still expect links without the `tron:` prefix
