### PR TITLE
fix: harden TRON RPC and late payment monitoring

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Nethereum.JsonRpc.Client;
 using System.Security.Claims;
+using BTCPayServer.Data;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Configuration;
 using BTCPayServer.Plugins.USDt.Controllers;
@@ -10,8 +11,10 @@ using BTCPayServer.Plugins.USDt.Configuration.Tron;
 using BTCPayServer.Plugins.USDt.Services.Payments;
 using BTCPayServer.Tests;
 using BTCPayServer.Client.Models;
+using BTCPayServer.Services.Invoices;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;
+using Nethereum.Hex.HexTypes;
 using NBitcoin;
 using NBXplorer;
 using Newtonsoft.Json.Linq;
@@ -71,6 +74,119 @@ public class FastTests : UnitTestBase
     }
 
     [Fact]
+    public async Task TrackedInvoicesMergePendingAndExpiredWithinGraceAfterRestart()
+    {
+        var now = DateTimeOffset.Parse("2026-08-21T12:00:00Z");
+        var paymentMethodId = new PaymentMethodId("USDT-TRON");
+        var source = new TestInvoiceSource
+        {
+            MonitoredInvoices =
+            [
+                CreateInvoice("new", InvoiceStatus.New, now.AddHours(1), paymentMethodId, "TNew"),
+                CreateInvoice("processing", InvoiceStatus.Processing, now.AddHours(1), paymentMethodId, "TProcessing")
+            ],
+            ExpiredInvoices =
+            [
+                CreateInvoice("grace", InvoiceStatus.Expired, now.AddMinutes(10), paymentMethodId, "TGrace"),
+                CreateInvoice("past-grace", InvoiceStatus.Expired, now.AddSeconds(-1), paymentMethodId, "TPast"),
+                CreateInvoice("settled", InvoiceStatus.Settled, now.AddMinutes(10), paymentMethodId, "TSettled"),
+                CreateInvoice("invalid", InvoiceStatus.Invalid, now.AddMinutes(10), paymentMethodId, "TInvalid")
+            ]
+        };
+        var provider = new USDtTrackedInvoiceProvider(source, new TestTimeProvider(now));
+
+        var tracked = await provider.GetTrackedInvoices(paymentMethodId, TestContext.Current.CancellationToken);
+
+        Assert.Equal(["grace", "new", "processing"], tracked.Select(invoice => invoice.Id).Order().ToArray());
+        Assert.Equal(now - USDtTrackedInvoiceProvider.BootstrapLookback, source.ExpiredStartDate);
+        Assert.Equal(1, source.ExpiredQueryCount);
+    }
+
+    [Fact]
+    public async Task TrackedInvoiceRefreshReleasesSettledInvoices()
+    {
+        var now = DateTimeOffset.Parse("2026-08-21T12:00:00Z");
+        var paymentMethodId = new PaymentMethodId("USDT-TRON");
+        var timeProvider = new TestTimeProvider(now);
+        var source = new TestInvoiceSource
+        {
+            MonitoredInvoices =
+            [
+                CreateInvoice("invoice", InvoiceStatus.New, now.AddHours(1), paymentMethodId, "TAddress")
+            ]
+        };
+        var provider = new USDtTrackedInvoiceProvider(source, timeProvider);
+        Assert.Single(await provider.GetTrackedInvoices(paymentMethodId, TestContext.Current.CancellationToken));
+
+        source.MonitoredInvoices = [];
+        source.RefreshedInvoices =
+        [
+            CreateInvoice("invoice", InvoiceStatus.Settled, now.AddHours(1), paymentMethodId, "TAddress")
+        ];
+        timeProvider.UtcNow += USDtTrackedInvoiceProvider.RefreshInterval;
+
+        Assert.Empty(await provider.GetTrackedInvoices(paymentMethodId, TestContext.Current.CancellationToken));
+        Assert.Equal(1, source.RefreshQueryCount);
+    }
+
+    [Fact]
+    public async Task AddressReservationEndsAtMonitoringExpiration()
+    {
+        var now = DateTimeOffset.Parse("2026-08-21T12:00:00Z");
+        var paymentMethodId = new PaymentMethodId("USDT-TRON");
+        var timeProvider = new TestTimeProvider(now);
+        var source = new TestInvoiceSource
+        {
+            ExpiredInvoices =
+            [
+                CreateInvoice("late", InvoiceStatus.Expired, now.AddMinutes(5), paymentMethodId, "TReserved")
+            ]
+        };
+        var provider = new USDtTrackedInvoiceProvider(source, timeProvider);
+
+        Assert.Equal(
+            ["TReserved"],
+            await USDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, provider));
+
+        timeProvider.UtcNow = now.AddMinutes(5);
+
+        Assert.Empty(await USDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, provider));
+    }
+
+    [Fact]
+    public async Task ExpiredInvoiceRetainsPaidLateStatusWhileTracked()
+    {
+        var now = DateTimeOffset.Parse("2026-08-21T12:00:00Z");
+        var paymentMethodId = new PaymentMethodId("USDT-TRON");
+        var invoice = CreateInvoice(
+            "paid-late",
+            InvoiceStatus.Expired,
+            now.AddMinutes(5),
+            paymentMethodId,
+            "TLate");
+        invoice.ExceptionStatus = InvoiceExceptionStatus.PaidLate;
+        var source = new TestInvoiceSource { ExpiredInvoices = [invoice] };
+        var provider = new USDtTrackedInvoiceProvider(source, new TestTimeProvider(now));
+
+        var tracked = Assert.Single(
+            await provider.GetTrackedInvoices(paymentMethodId, TestContext.Current.CancellationToken));
+
+        Assert.Equal(InvoiceStatus.Expired, tracked.Status);
+        Assert.Equal(InvoiceExceptionStatus.PaidLate, tracked.ExceptionStatus);
+    }
+
+    [Fact]
+    public void BlockTimestampUsesUnixTimeAndRejectsUnavailableValues()
+    {
+        var expected = DateTimeOffset.Parse("2023-11-14T22:13:20Z");
+
+        Assert.True(USDtListenerShared.TryGetBlockTimestamp(new HexBigInteger(1_700_000_000), out var timestamp));
+        Assert.Equal(expected, timestamp);
+        Assert.False(USDtListenerShared.TryGetBlockTimestamp(null, out _));
+        Assert.False(USDtListenerShared.TryGetBlockTimestamp(new HexBigInteger(0), out _));
+    }
+
+    [Fact]
     public void TronStoreSettingsDetectDuplicateSubmittedAddresses()
     {
         var duplicate = UITronUSDtLikeStoreController.FindDuplicateAddress(
@@ -105,7 +221,7 @@ public class FastTests : UnitTestBase
             12.34m,
             false);
 
-        Assert.Equal("TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34", result);
+        Assert.Equal("tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34", result);
     }
 
     [Fact]
@@ -116,7 +232,7 @@ public class FastTests : UnitTestBase
             12.34m,
             true);
 
-        Assert.Equal("TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs", result);
+        Assert.Equal("tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs", result);
     }
 
     [Fact]
@@ -471,6 +587,75 @@ public class FastTests : UnitTestBase
         public static long GetHeadLag(EVMUSDtLikeConfigurationItem configuration)
         {
             return new TestableEvmListener().GetHeadLagBlocks(configuration);
+        }
+    }
+
+    private static InvoiceEntity CreateInvoice(
+        string id,
+        InvoiceStatus status,
+        DateTimeOffset monitoringExpiration,
+        PaymentMethodId paymentMethodId,
+        string destination)
+    {
+        var invoice = new InvoiceEntity
+        {
+            Id = id,
+            Status = status,
+            MonitoringExpiration = monitoringExpiration,
+            Currency = "USD",
+            Price = 1m
+        };
+        invoice.SetPaymentPrompt(paymentMethodId, new PaymentPrompt
+        {
+            Currency = "USDt",
+            Destination = destination,
+            Divisibility = 6
+        });
+        return invoice;
+    }
+
+    private sealed class TestInvoiceSource : IUSDtInvoiceSource
+    {
+        public InvoiceEntity[] MonitoredInvoices { get; set; } = [];
+        public InvoiceEntity[] ExpiredInvoices { get; set; } = [];
+        public InvoiceEntity[] RefreshedInvoices { get; set; } = [];
+        public DateTimeOffset? ExpiredStartDate { get; private set; }
+        public int ExpiredQueryCount { get; private set; }
+        public int RefreshQueryCount { get; private set; }
+
+        public Task<InvoiceEntity[]> GetMonitoredInvoices(
+            PaymentMethodId paymentMethodId,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(MonitoredInvoices);
+        }
+
+        public Task<InvoiceEntity[]> GetExpiredInvoicesSince(
+            DateTimeOffset startDate,
+            CancellationToken cancellationToken)
+        {
+            ExpiredStartDate = startDate;
+            ExpiredQueryCount++;
+            return Task.FromResult(ExpiredInvoices);
+        }
+
+        public Task<InvoiceEntity[]> GetInvoices(
+            string[] invoiceIds,
+            CancellationToken cancellationToken)
+        {
+            RefreshQueryCount++;
+            return Task.FromResult(
+                RefreshedInvoices.Where(invoice => invoiceIds.Contains(invoice.Id)).ToArray());
+        }
+    }
+
+    private sealed class TestTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return UtcNow;
         }
     }
 

--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Nethereum.JsonRpc.Client;
 using System.Security.Claims;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Configuration;
@@ -34,6 +35,39 @@ public class FastTests : UnitTestBase
         Assert.True(TronUSDtAddressHelper.IsValid("TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs"));
         Assert.False(TronUSDtAddressHelper.IsValid("TG2XXyExBkPp9nzdajDZsozEu4BkaSJozs"));
         Assert.False(TronUSDtAddressHelper.IsValid("TG3xXyExBkPp9nzdajDZsozEu4BkaSJozs"));
+    }
+
+    [Fact]
+    public void TronPollingUsesConfiguredBlockTime()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(3), USDtListenerShared.GetBlockPollingDelay(3));
+        Assert.Equal(TimeSpan.FromSeconds(1), USDtListenerShared.GetBlockPollingDelay(0.25));
+    }
+
+    [Fact]
+    public void RateLimitBackoffIsJitteredAndCapped()
+    {
+        Assert.Equal(USDtListenerShared.InitialRateLimitBackoffMs, 5_000);
+        Assert.Equal(5_000, USDtListenerShared.CalculateRateLimitDelayMs(5_000, 0));
+        Assert.Equal(5_500, USDtListenerShared.CalculateRateLimitDelayMs(5_000, 0.5));
+        Assert.Equal(6_000, USDtListenerShared.CalculateRateLimitDelayMs(5_000, 1));
+        Assert.Equal(60_000, USDtListenerShared.CalculateRateLimitDelayMs(60_000, 1));
+
+        Assert.Equal(10_000, USDtListenerShared.GetNextRateLimitBackoffMs(5_000));
+        Assert.Equal(60_000, USDtListenerShared.GetNextRateLimitBackoffMs(40_000));
+        Assert.Equal(60_000, USDtListenerShared.GetNextRateLimitBackoffMs(60_000));
+    }
+
+    [Theory]
+    [InlineData("Response status code does not indicate success: 429 (Too Many Requests).", true)]
+    [InlineData("403 Forbidden: The key exceeds the frequency limit", true)]
+    [InlineData("403 Forbidden: invalid API key", false)]
+    [InlineData("500 Internal Server Error", false)]
+    public void RateLimitDetectionIsSelective(string message, bool expected)
+    {
+        var exception = new RpcClientUnknownException("RPC failure", new HttpRequestException(message));
+
+        Assert.Equal(expected, USDtListenerShared.IsRateLimitException(exception));
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.USDt/Controllers/GreenfieldTronUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/GreenfieldTronUSDtLikeStoreController.cs
@@ -23,7 +23,7 @@ namespace BTCPayServer.Plugins.USDt.Controllers;
 public class GreenfieldTronUSDtLikeStoreController(
     TronUSDtRPCProvider tronUSDtRpcProvider,
     PaymentMethodHandlerDictionary handlers,
-    InvoiceRepository invoiceRepository,
+    USDtTrackedInvoiceProvider trackedInvoiceProvider,
     USDtPluginConfiguration pluginConfiguration) : ControllerBase
 {
 
@@ -46,7 +46,7 @@ public class GreenfieldTronUSDtLikeStoreController(
         var balances =
             await tronUSDtRpcProvider.GetBalances(paymentMethodId, [.. matchedPaymentMethodConfig.Addresses]);
         var reservedAddresses =
-            await TronUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, invoiceRepository);
+            await TronUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, trackedInvoiceProvider);
 
         var data = new TronUSDtPaymentMethodInformation
         {

--- a/BTCPayServer.Plugins.USDt/Controllers/UIEVMUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/UIEVMUSDtLikeStoreController.cs
@@ -28,7 +28,7 @@ public class UIEVMUSDtLikeStoreController(
     StoreRepository storeRepository,
     EVMUSDtRPCProvider evmUsdTRpcProvider,
     PaymentMethodHandlerDictionary handlers,
-    InvoiceRepository invoiceRepository,
+    USDtTrackedInvoiceProvider trackedInvoiceProvider,
     DisplayFormatter displayFormatter,
     USDtPluginConfiguration pluginConfiguration,
     EventAggregator eventAggregator) : Controller
@@ -84,7 +84,7 @@ public class UIEVMUSDtLikeStoreController(
         var balances =
             await evmUsdTRpcProvider.GetBalances(paymentMethodId, [.. matchedPaymentMethodConfig.Addresses]);
         var reservedAddresses =
-            await EVMUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, invoiceRepository);
+            await EVMUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, trackedInvoiceProvider);
 
         return View(new EditEVMUSDtPaymentMethodViewModel
         {

--- a/BTCPayServer.Plugins.USDt/Controllers/UITronUSDtLikeStoreController.cs
+++ b/BTCPayServer.Plugins.USDt/Controllers/UITronUSDtLikeStoreController.cs
@@ -29,7 +29,7 @@ public class UITronUSDtLikeStoreController(
     StoreRepository storeRepository,
     TronUSDtRPCProvider tronUSDtRpcProvider,
     PaymentMethodHandlerDictionary handlers,
-    InvoiceRepository invoiceRepository,
+    USDtTrackedInvoiceProvider trackedInvoiceProvider,
     DisplayFormatter displayFormatter,
     USDtPluginConfiguration pluginConfiguration,
     EventAggregator eventAggregator) : Controller
@@ -87,7 +87,7 @@ public class UITronUSDtLikeStoreController(
             .ToArray();
         var balances = await tronUSDtRpcProvider.GetBalances(paymentMethodId, addresses);
         var reservedAddresses =
-            await TronUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, invoiceRepository);
+            await TronUSDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, trackedInvoiceProvider);
 
         return View(new EditTronUSDtPaymentMethodViewModel
         {

--- a/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
@@ -21,21 +21,21 @@ using Nethereum.RPC.Eth.DTOs;
 namespace BTCPayServer.Plugins.USDt.Services;
 
 public class EVMUSDtListener(
-    InvoiceRepository invoiceRepository,
     ISettingsRepository settingsRepository,
     EventAggregator eventAggregator,
     EVMUSDtRPCProvider rpcProvider,
     USDtPluginConfiguration usdtPluginConfiguration,
     USDtChainActivationService activationService,
+    USDtTrackedInvoiceProvider trackedInvoiceProvider,
     ILogger<EVMUSDtListener> logger,
     PaymentMethodHandlerDictionary handlers,
     PaymentService paymentService)
     : USDtListener<EVMUSDtLikeConfigurationItem, EVMUSDtPaymentData>(
-        invoiceRepository,
         settingsRepository,
         eventAggregator,
         rpcProvider,
         activationService,
+        trackedInvoiceProvider,
         logger,
         handlers,
         paymentService)

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodConfig.cs
@@ -1,21 +1,5 @@
-using System.Threading.Tasks;
-using BTCPayServer.Payments;
-using BTCPayServer.Services.Invoices;
-
 namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
 public class EVMUSDtPaymentMethodConfig : USDtPaymentMethodConfig
 {
-    public async Task<string?> GetOneNotReservedAddress(PaymentMethodId paymentMethodId,
-        InvoiceRepository invoiceRepository)
-    {
-        return await base.GetOneNotReservedAddress(paymentMethodId, invoiceRepository, USDtListenerShared.StatusToTrack);
-    }
-
-    public static async Task<string[]> GetReservedAddresses(PaymentMethodId paymentMethodId,
-        InvoiceRepository invoiceRepository)
-    {
-        return await USDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, invoiceRepository,
-            USDtListenerShared.StatusToTrack);
-    }
 }

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentMethodHandler.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Configuration.EVM;
-using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -14,7 +13,7 @@ public class EVMUSDtPaymentMethodHandler(
     EVMUSDtLikeConfigurationItem configurationItem,
     EVMUSDtRPCProvider rpcProvider,
     CurrencyNameTable currencyNameTable,
-    InvoiceRepository invoiceRepository) : IPaymentMethodHandler
+    USDtTrackedInvoiceProvider trackedInvoiceProvider) : IPaymentMethodHandler
 {
     public JsonSerializer Serializer { get; } = BlobSerializer.CreateSerializer().Serializer;
 
@@ -39,7 +38,7 @@ public class EVMUSDtPaymentMethodHandler(
 
         var details = new EVMUSDtLikeOnChainPaymentMethodDetails();
         var availableAddress = await ParsePaymentMethodConfig(context.PaymentMethodConfig)
-                                   .GetOneNotReservedAddress(context.PaymentMethodId, invoiceRepository) ??
+                                   .GetOneNotReservedAddress(context.PaymentMethodId, trackedInvoiceProvider) ??
                                throw new PaymentMethodUnavailableException(
                                    $"All your {configurationItem.Chain} addresses are currently waiting payment");
         context.Prompt.Destination = availableAddress;

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikePaymentMethodHandler.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtLikePaymentMethodHandler.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using BTCPayServer.Data;
 using BTCPayServer.Payments;
 using BTCPayServer.Plugins.USDt.Configuration.Tron;
-using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -14,7 +13,7 @@ public class TronUSDtLikePaymentMethodHandler(
     TronUSDtLikeConfigurationItem configurationItem,
     TronUSDtRPCProvider tronUSDtRpcProvider,
     CurrencyNameTable currencyNameTable,
-    InvoiceRepository invoiceRepository) : IPaymentMethodHandler
+    USDtTrackedInvoiceProvider trackedInvoiceProvider) : IPaymentMethodHandler
 {
     public JsonSerializer Serializer { get; } = BlobSerializer.CreateSerializer().Serializer;
 
@@ -39,7 +38,7 @@ public class TronUSDtLikePaymentMethodHandler(
             ExcludeAmountFromPaymentLink = config.ExcludeAmountFromPaymentLink
         };
         var availableAddress = await config
-                                   .GetOneNotReservedAddress(context.PaymentMethodId, invoiceRepository) ??
+                                   .GetOneNotReservedAddress(context.PaymentMethodId, trackedInvoiceProvider) ??
                                throw new PaymentMethodUnavailableException(
                                    "All your TRON addresses are currently waiting payment");
         context.Prompt.Destination = availableAddress;

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentMethodConfig.cs
@@ -1,23 +1,6 @@
-using System.Threading.Tasks;
-using BTCPayServer.Payments;
-using BTCPayServer.Services.Invoices;
-
 namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
 public class TronUSDtPaymentMethodConfig : USDtPaymentMethodConfig
 {
     public bool ExcludeAmountFromPaymentLink { get; set; }
-
-    public async Task<string?> GetOneNotReservedAddress(PaymentMethodId paymentMethodId,
-        InvoiceRepository invoiceRepository)
-    {
-        return await base.GetOneNotReservedAddress(paymentMethodId, invoiceRepository, USDtListenerShared.StatusToTrack);
-    }
-
-    public static async Task<string[]> GetReservedAddresses(PaymentMethodId paymentMethodId,
-        InvoiceRepository invoiceRepository)
-    {
-        return await USDtPaymentMethodConfig.GetReservedAddresses(paymentMethodId, invoiceRepository,
-            USDtListenerShared.StatusToTrack);
-    }
 }

--- a/BTCPayServer.Plugins.USDt/Services/Payments/USDtPaymentMethodConfig.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/USDtPaymentMethodConfig.cs
@@ -1,9 +1,6 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using BTCPayServer.Client.Models;
 using BTCPayServer.Payments;
-using BTCPayServer.Services.Invoices;
 
 namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
@@ -34,21 +31,17 @@ public class USDtPaymentMethodConfig
     }
 
     public async Task<string?> GetOneNotReservedAddress(PaymentMethodId paymentMethodId,
-        InvoiceRepository invoiceRepository,
-        IEnumerable<InvoiceStatus> trackedStatuses)
+        USDtTrackedInvoiceProvider trackedInvoiceProvider)
     {
-        var allReservedAddresses = await GetReservedAddresses(paymentMethodId, invoiceRepository, trackedStatuses);
+        var allReservedAddresses = await GetReservedAddresses(paymentMethodId, trackedInvoiceProvider);
         return Addresses.Except(allReservedAddresses).FirstOrDefault();
     }
 
     public static async Task<string[]> GetReservedAddresses(PaymentMethodId paymentMethodId,
-        InvoiceRepository invoiceRepository,
-        IEnumerable<InvoiceStatus> trackedStatuses)
+        USDtTrackedInvoiceProvider trackedInvoiceProvider)
     {
-        var trackedStatusSet = trackedStatuses.ToHashSet();
-        var pendingInvoices = (await invoiceRepository.GetMonitoredInvoices(paymentMethodId, true))
-            .Where(i => trackedStatusSet.Contains(i.Status));
-        return pendingInvoices
+        var trackedInvoices = await trackedInvoiceProvider.GetTrackedInvoices(paymentMethodId);
+        return trackedInvoices
             .Select(i => i.GetPaymentPrompt(paymentMethodId)?.Destination)
             .Where(s => s is not null)
             .Select(s => s!)

--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
@@ -20,21 +20,21 @@ using Nethereum.RPC.Eth.DTOs;
 namespace BTCPayServer.Plugins.USDt.Services;
 
 public class TronUSDtListener(
-    InvoiceRepository invoiceRepository,
     ISettingsRepository settingsRepository,
     EventAggregator eventAggregator,
     TronUSDtRPCProvider tronUSDtRpcProvider,
     USDtPluginConfiguration usdtPluginConfiguration,
     USDtChainActivationService activationService,
+    USDtTrackedInvoiceProvider trackedInvoiceProvider,
     ILogger<TronUSDtListener> logger,
     PaymentMethodHandlerDictionary handlers,
     PaymentService paymentService)
     : USDtListener<TronUSDtLikeConfigurationItem, TronUSDtLikePaymentData>(
-        invoiceRepository,
         settingsRepository,
         eventAggregator,
         tronUSDtRpcProvider,
         activationService,
+        trackedInvoiceProvider,
         logger,
         handlers,
         paymentService)

--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
@@ -51,6 +51,13 @@ public class TronUSDtListener(
 
     protected override string RateLimitNodeName => "Tron";
 
+    protected override bool UseExponentialRateLimitBackoff => true;
+
+    protected override TimeSpan GetHeadPollingDelay(TronUSDtLikeConfigurationItem configurationItem)
+    {
+        return USDtListenerShared.GetBlockPollingDelay(configurationItem.BlockTimeSeconds);
+    }
+
     protected override long CreateInitialLastBlockHeight(HexBigInteger latestBlockNumber)
     {
         return (long)latestBlockNumber.Value;

--- a/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
@@ -54,6 +54,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
     protected virtual bool UseExponentialRateLimitBackoff => false;
     protected virtual long CreateInitialLastBlockHeight(HexBigInteger latestBlockNumber) => (long)latestBlockNumber.Value - 1;
     protected virtual long GetHeadLagBlocks(TConfigurationItem configurationItem) => 0;
+    protected virtual TimeSpan GetHeadPollingDelay(TConfigurationItem configurationItem) => TimeSpan.FromSeconds(1);
     protected virtual LogLevel EmptyQueueBlockAdvanceLogLevel => LogLevel.Information;
     protected virtual IDisposable? BeginLoggingScope(PaymentMethodId paymentMethodId) => null;
     protected virtual string NormalizeDestinationKey(string destination) => destination.ToLowerInvariant();
@@ -84,7 +85,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
     {
         var paymentMethodId = configurationItem.GetPaymentMethodId();
         var logContext = GetLogContext(configurationItem);
-        var rateLimitBackoffMs = 5_000;
+        var rateLimitBackoffMs = USDtListenerShared.InitialRateLimitBackoffMs;
         while (!stoppingToken.IsCancellationRequested)
             try
             {
@@ -151,7 +152,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                             logger.LogDebug(
                                 "Waiting for a safe indexing head on {Listener}, next={NextBlockNumber}, latest={LatestBlockNumber}, lag={HeadLagBlocks}",
                                 logContext, nextBlockHeight, latestBlockNumber.Value, safeHeadLagBlocks);
-                            await Task.Delay(1_000, stoppingToken);
+                            await Task.Delay(GetHeadPollingDelay(configurationItem), stoppingToken);
                             continue;
                         }
 
@@ -172,12 +173,12 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                             logger.LogInformation(
                                 "Block not present on node yet for {Listener} {BlockNumber}",
                                 logContext, listenerState.LastBlockHeight);
-                            await Task.Delay(1_000, stoppingToken);
+                            await Task.Delay(GetHeadPollingDelay(configurationItem), stoppingToken);
                         }
                     }
 
                     await SetTrackingState(configurationItem, listenerState);
-                    rateLimitBackoffMs = 5_000;
+                    rateLimitBackoffMs = USDtListenerShared.InitialRateLimitBackoffMs;
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -197,16 +198,18 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                     logContext);
                 await Task.Delay(5_000, stoppingToken);
             }
-            catch (RpcClientUnknownException e) when (e.InnerException?.Message?.Contains("429 (Too Many Requests)") ==
-                                                      true)
+            catch (RpcClientUnknownException e) when (USDtListenerShared.IsRateLimitException(e))
             {
                 if (UseExponentialRateLimitBackoff)
                 {
+                    var retryDelayMs = USDtListenerShared.CalculateRateLimitDelayMs(
+                        rateLimitBackoffMs,
+                        Random.Shared.NextDouble());
                     logger.LogWarning(
                         "Rate limit exceeded while indexing {Listener}, use a {NodeName} node with higher limits if possible. Retrying in {DelayMs} ms",
-                        logContext, RateLimitNodeName, rateLimitBackoffMs);
-                    await Task.Delay(rateLimitBackoffMs, stoppingToken);
-                    rateLimitBackoffMs = Math.Min(rateLimitBackoffMs * 2, 60_000);
+                        logContext, RateLimitNodeName, retryDelayMs);
+                    await Task.Delay(retryDelayMs, stoppingToken);
+                    rateLimitBackoffMs = USDtListenerShared.GetNextRateLimitBackoffMs(rateLimitBackoffMs);
                 }
                 else
                 {

--- a/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
@@ -22,11 +22,11 @@ using Nethereum.Web3;
 namespace BTCPayServer.Plugins.USDt.Services;
 
 public abstract class USDtListener<TConfigurationItem, TPaymentData>(
-    InvoiceRepository invoiceRepository,
     ISettingsRepository settingsRepository,
     EventAggregator eventAggregator,
     USDtRPCProvider<TConfigurationItem> rpcProvider,
     USDtChainActivationService activationService,
+    USDtTrackedInvoiceProvider trackedInvoiceProvider,
     ILogger logger,
     PaymentMethodHandlerDictionary handlers,
     PaymentService paymentService) : IHostedService
@@ -127,7 +127,10 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
 
                 while (!stoppingToken.IsCancellationRequested)
                 {
-                    if (!await HasTrackedInvoices(paymentMethodId, stoppingToken))
+                    var invoices = (await trackedInvoiceProvider.GetTrackedInvoices(paymentMethodId, stoppingToken))
+                        .Where(invoice => invoice.GetPaymentPrompt(paymentMethodId)?.Activated is true)
+                        .ToArray();
+                    if (invoices.Length == 0)
                     {
                         var lastBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync();
                         if (lastBlockNumber.Value > listenerState.LastBlockHeight)
@@ -162,7 +165,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
 
                         if (block != null)
                         {
-                            await OnNewBlockToIndex(paymentMethodId, block, stoppingToken);
+                            await OnNewBlockToIndex(paymentMethodId, invoices, block, stoppingToken);
                             logger.LogInformation("New block indexed for {Listener} {BlockNumber}",
                                 logContext, block.Number);
 
@@ -236,12 +239,6 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
         return await settingsRepository.GetSettingAsync<EVMBasedListenerState>(GetListenerStateSettingKey(config));
     }
 
-    private async Task<bool> HasTrackedInvoices(PaymentMethodId paymentMethodId, CancellationToken stoppingToken)
-    {
-        return (await invoiceRepository.GetMonitoredInvoices(paymentMethodId, true, stoppingToken))
-            .Any(i => USDtListenerShared.StatusToTrack.Contains(i.Status));
-    }
-
     private Task ReceivedPayment(InvoiceEntity invoice, PaymentEntity payment)
     {
         logger.LogInformation(
@@ -274,6 +271,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
             .ToDictionary(group => group.Key, group => group.First().Invoice);
 
         var matches = await GetTransfersAsync(paymentMethodId, block, invoicesPerAddress, stoppingToken);
+        var paymentTimestamp = GetPaymentTimestamp(block);
         foreach (var match in matches)
         {
             if (!invoicesPerAddress.TryGetValue(match.DestinationKey, out var invoice))
@@ -287,6 +285,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                 match.TransactionId,
                 0,
                 (long)block.Number.Value,
+                paymentTimestamp,
                 invoice);
         }
 
@@ -325,10 +324,11 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
 
     private async Task OnNewBlockToIndex(
         PaymentMethodId paymentMethodId,
+        InvoiceEntity[] invoices,
         BlockWithTransactions block,
         CancellationToken stoppingToken)
     {
-        await UpdateAnyPendingPayment(paymentMethodId, block, stoppingToken);
+        await UpdatePaymentStates(paymentMethodId, invoices, block, stoppingToken);
     }
 
     private async Task HandlePaymentData(
@@ -339,6 +339,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
         string txId,
         int confirmations,
         long blockHeight,
+        DateTimeOffset paymentTimestamp,
         InvoiceEntity invoice)
     {
         var config = GetConfig(paymentMethodId);
@@ -353,7 +354,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
         {
             Status = details.PaymentConfirmed(invoice.SpeedPolicy) ? PaymentStatus.Settled : PaymentStatus.Processing,
             Amount = totalAmountBigDecimal,
-            Created = DateTimeOffset.UtcNow,
+            Created = paymentTimestamp,
             Id = txId,
             Currency = config.Currency,
             InvoiceDataId = invoice.Id
@@ -364,20 +365,16 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
             await ReceivedPayment(invoice, payment);
     }
 
-    private async Task UpdateAnyPendingPayment(
-        PaymentMethodId paymentMethodId,
-        BlockWithTransactions block,
-        CancellationToken stoppingToken)
+    private DateTimeOffset GetPaymentTimestamp(BlockWithTransactions block)
     {
-        var invoices = (await invoiceRepository.GetMonitoredInvoices(paymentMethodId, true, stoppingToken))
-            .Where(i => USDtListenerShared.StatusToTrack.Contains(i.Status))
-            .Where(i => i.GetPaymentPrompt(paymentMethodId)?.Activated is true)
-            .ToArray();
+        var now = DateTimeOffset.UtcNow;
+        if (USDtListenerShared.TryGetBlockTimestamp(block.Timestamp, out var timestamp))
+            return timestamp;
 
-        if (invoices.Length == 0)
-            return;
-
-        await UpdatePaymentStates(paymentMethodId, invoices, block, stoppingToken);
+        logger.LogWarning(
+            "Block {BlockNumber} did not contain a valid Unix timestamp; using the current time for detected payments",
+            block.Number);
+        return now;
     }
 
     private static IEnumerable<PaymentEntity> GetPendingPayments(InvoiceEntity invoice, PaymentMethodId paymentMethodId)

--- a/BTCPayServer.Plugins.USDt/Services/USDtListenerShared.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListenerShared.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using BTCPayServer.Client.Models;
 
@@ -5,9 +6,53 @@ namespace BTCPayServer.Plugins.USDt.Services;
 
 public static class USDtListenerShared
 {
+    internal const int InitialRateLimitBackoffMs = 5_000;
+    internal const int MaximumRateLimitBackoffMs = 60_000;
+
     public static readonly IReadOnlyList<InvoiceStatus> StatusToTrack =
     [
         InvoiceStatus.New,
         InvoiceStatus.Processing
     ];
+
+    internal static TimeSpan GetBlockPollingDelay(double blockTimeSeconds)
+    {
+        return TimeSpan.FromSeconds(Math.Max(1, blockTimeSeconds));
+    }
+
+    internal static int CalculateRateLimitDelayMs(int backoffMs, double jitterUnit)
+    {
+        jitterUnit = Math.Clamp(jitterUnit, 0, 1);
+        var jitterMultiplier = 1.0 + (jitterUnit * 0.2);
+        return Math.Min(
+            MaximumRateLimitBackoffMs,
+            Math.Max(1, (int)Math.Round(backoffMs * jitterMultiplier)));
+    }
+
+    internal static int GetNextRateLimitBackoffMs(int backoffMs)
+    {
+        return Math.Min(backoffMs * 2, MaximumRateLimitBackoffMs);
+    }
+
+    internal static bool IsRateLimitException(Exception exception)
+    {
+        for (Exception? current = exception; current != null; current = current.InnerException)
+        {
+            var message = current.Message;
+            if (message.Contains("429", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Too Many Requests", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            var isForbidden = message.Contains("403", StringComparison.OrdinalIgnoreCase) ||
+                              message.Contains("Forbidden", StringComparison.OrdinalIgnoreCase);
+            var describesRateLimit = message.Contains("rate limit", StringComparison.OrdinalIgnoreCase) ||
+                                     message.Contains("frequency limit", StringComparison.OrdinalIgnoreCase) ||
+                                     message.Contains("quota", StringComparison.OrdinalIgnoreCase) ||
+                                     message.Contains("too many requests", StringComparison.OrdinalIgnoreCase);
+            if (isForbidden && describesRateLimit)
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/BTCPayServer.Plugins.USDt/Services/USDtListenerShared.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListenerShared.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using BTCPayServer.Client.Models;
+using Nethereum.Hex.HexTypes;
 
 namespace BTCPayServer.Plugins.USDt.Services;
 
@@ -54,5 +55,22 @@ public static class USDtListenerShared
         }
 
         return false;
+    }
+
+    internal static bool TryGetBlockTimestamp(HexBigInteger? blockTimestamp, out DateTimeOffset timestamp)
+    {
+        timestamp = default;
+        if (blockTimestamp?.Value is not { } value || value <= 0 || value > long.MaxValue)
+            return false;
+
+        try
+        {
+            timestamp = DateTimeOffset.FromUnixTimeSeconds((long)value);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
     }
 }

--- a/BTCPayServer.Plugins.USDt/Services/USDtTrackedInvoiceProvider.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtTrackedInvoiceProvider.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+using BTCPayServer.Services.Invoices;
+
+namespace BTCPayServer.Plugins.USDt.Services;
+
+public sealed class USDtTrackedInvoiceProvider
+{
+    internal static readonly TimeSpan BootstrapLookback = TimeSpan.FromDays(49);
+    internal static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(30);
+
+    private readonly IUSDtInvoiceSource _invoiceSource;
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<PaymentMethodId, TrackingState> _states = new();
+
+    public USDtTrackedInvoiceProvider(InvoiceRepository invoiceRepository)
+        : this(new InvoiceRepositoryUSDtInvoiceSource(invoiceRepository), TimeProvider.System)
+    {
+    }
+
+    internal USDtTrackedInvoiceProvider(IUSDtInvoiceSource invoiceSource, TimeProvider timeProvider)
+    {
+        _invoiceSource = invoiceSource;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<InvoiceEntity[]> GetTrackedInvoices(
+        PaymentMethodId paymentMethodId,
+        CancellationToken cancellationToken = default)
+    {
+        var state = _states.GetOrAdd(paymentMethodId, _ => new TrackingState());
+        await state.Gate.WaitAsync(cancellationToken);
+        try
+        {
+            var now = _timeProvider.GetUtcNow();
+
+            if (!state.Bootstrapped)
+            {
+                var expiredInvoices = await _invoiceSource.GetExpiredInvoicesSince(
+                    now - BootstrapLookback,
+                    cancellationToken);
+                AddMatchingInvoices(state.Invoices, paymentMethodId, expiredInvoices);
+                state.Bootstrapped = true;
+                state.LastRefresh = now;
+            }
+            else if (now - state.LastRefresh >= RefreshInterval)
+            {
+                await RefreshKnownInvoices(state, cancellationToken);
+                state.LastRefresh = now;
+            }
+
+            var monitoredInvoices = await _invoiceSource.GetMonitoredInvoices(paymentMethodId, cancellationToken);
+            AddMatchingInvoices(state.Invoices, paymentMethodId, monitoredInvoices);
+
+            foreach (var (invoiceId, invoice) in state.Invoices.ToArray())
+            {
+                if (!ShouldTrack(invoice, paymentMethodId, now))
+                    state.Invoices.Remove(invoiceId);
+            }
+
+            return state.Invoices.Values.ToArray();
+        }
+        finally
+        {
+            state.Gate.Release();
+        }
+    }
+
+    internal static bool ShouldTrack(
+        InvoiceEntity invoice,
+        PaymentMethodId paymentMethodId,
+        DateTimeOffset now)
+    {
+        var prompt = invoice.GetPaymentPrompt(paymentMethodId);
+        if (string.IsNullOrEmpty(prompt?.Destination))
+            return false;
+
+        if (USDtListenerShared.StatusToTrack.Contains(invoice.Status))
+            return true;
+
+        return invoice.Status == InvoiceStatus.Expired && invoice.MonitoringExpiration > now;
+    }
+
+    private async Task RefreshKnownInvoices(TrackingState state, CancellationToken cancellationToken)
+    {
+        var invoiceIds = state.Invoices.Keys.ToArray();
+        if (invoiceIds.Length == 0)
+            return;
+
+        var refreshedInvoices = await _invoiceSource.GetInvoices(invoiceIds, cancellationToken);
+        var refreshedById = refreshedInvoices.ToDictionary(invoice => invoice.Id);
+        foreach (var invoiceId in invoiceIds)
+        {
+            if (refreshedById.TryGetValue(invoiceId, out var invoice))
+                state.Invoices[invoiceId] = invoice;
+            else
+                state.Invoices.Remove(invoiceId);
+        }
+    }
+
+    private static void AddMatchingInvoices(
+        IDictionary<string, InvoiceEntity> destination,
+        PaymentMethodId paymentMethodId,
+        IEnumerable<InvoiceEntity> invoices)
+    {
+        foreach (var invoice in invoices)
+        {
+            if (!string.IsNullOrEmpty(invoice.GetPaymentPrompt(paymentMethodId)?.Destination))
+                destination[invoice.Id] = invoice;
+        }
+    }
+
+    private sealed class TrackingState
+    {
+        public SemaphoreSlim Gate { get; } = new(1, 1);
+        public Dictionary<string, InvoiceEntity> Invoices { get; } = new();
+        public bool Bootstrapped { get; set; }
+        public DateTimeOffset LastRefresh { get; set; }
+    }
+}
+
+internal interface IUSDtInvoiceSource
+{
+    Task<InvoiceEntity[]> GetMonitoredInvoices(
+        PaymentMethodId paymentMethodId,
+        CancellationToken cancellationToken);
+
+    Task<InvoiceEntity[]> GetExpiredInvoicesSince(
+        DateTimeOffset startDate,
+        CancellationToken cancellationToken);
+
+    Task<InvoiceEntity[]> GetInvoices(
+        string[] invoiceIds,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class InvoiceRepositoryUSDtInvoiceSource(InvoiceRepository invoiceRepository) : IUSDtInvoiceSource
+{
+    public Task<InvoiceEntity[]> GetMonitoredInvoices(
+        PaymentMethodId paymentMethodId,
+        CancellationToken cancellationToken)
+    {
+        return invoiceRepository.GetMonitoredInvoices(paymentMethodId, true, cancellationToken);
+    }
+
+    public Task<InvoiceEntity[]> GetExpiredInvoicesSince(
+        DateTimeOffset startDate,
+        CancellationToken cancellationToken)
+    {
+        return invoiceRepository.GetInvoices(new InvoiceQuery
+        {
+            Status = [InvoiceStatus.Expired.ToString()],
+            StartDate = startDate,
+            IncludeArchived = false,
+            OrderByDesc = false
+        }, cancellationToken);
+    }
+
+    public Task<InvoiceEntity[]> GetInvoices(
+        string[] invoiceIds,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return invoiceRepository.GetInvoices(invoiceIds);
+    }
+}

--- a/BTCPayServer.Plugins.USDt/USDtPlugin.cs
+++ b/BTCPayServer.Plugins.USDt/USDtPlugin.cs
@@ -53,6 +53,7 @@ public class USDtPlugin : BaseBTCPayServerPlugin
 
         services.AddSingleton(pluginConfiguration);
         services.AddSingleton<USDtChainActivationService>();
+        services.AddSingleton<USDtTrackedInvoiceProvider>();
         services.AddHostedService<USDtPluginConfigurationBootstrapper>();
 
         services.AddCurrencyData(new CurrencyData

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The default public TRON node is provided for demonstration and testing only. It 
 
 For production, use a private TRON node or a dedicated, authenticated RPC provider with sufficient availability and rate limits for your payment volume. Configure its JSON-RPC endpoint in the plugin's TRON server settings. Providers that use TronGrid authentication can be configured with the `TRON-PRO-API-KEY` header in the same settings.
 
+### Late-payment monitoring
+
+USDt invoice destinations remain reserved and monitored after invoice expiration until BTCPay's monitoring-expiration period ends. This grace period applies to TRON and EVM chains and is controlled by the store's existing invoice monitoring-expiration setting; the plugin does not add a separate setting. Payments discovered after invoice expiration keep BTCPay's `PaidLate` status.
+
 ## 🚀 Installation
 
 Install the plugin from the BTCPay Server > Settings > Plugin > Available Plugins, and restart.


### PR DESCRIPTION
## Summary

- pace TRON head polling at the configured block interval and use capped, jittered exponential backoff for selective RPC throttling responses
- share invoice tracking across listeners and address allocation so TRON and EVM invoices remain monitored and reserved through BTCPay monitoring expiration
- persist the block timestamp on discovered payments while retaining BTCPay late-payment status semantics
- document production TRON node expectations and BTCPay-controlled late-payment monitoring grace

## Related issues

- Relates to #49
- Relates to #52

## Verification

- git diff --check origin/master..HEAD
- dotnet build
- complete plugin test executable: 39 passed, 0 failed

The full build encountered the known transient staticwebassets output race once and passed unchanged on retry.
