### PR TITLE
fix: prevent payment link format checkout crashes

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/PaymentLinkExtensionTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/PaymentLinkExtensionTests.cs
@@ -1,0 +1,291 @@
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.USDt.Configuration;
+using BTCPayServer.Plugins.USDt.Configuration.EVM;
+using BTCPayServer.Plugins.USDt.Configuration.Tron;
+using BTCPayServer.Plugins.USDt.Services.Payments;
+using BTCPayServer.Services.Invoices;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace BTCPayServer.Plugins.USDt.Tests;
+
+[Trait("Fast", "Fast")]
+public class PaymentLinkExtensionTests
+{
+    private const string TronDestination = "TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs";
+    private const string EvmDestination = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+    private const string EvmDestinationLower = "0x742d35cc6634c0532925a3b844bc454e4438f44e";
+    private const string EvmContractLower = "0x1234567890123456789012345678901234567890";
+
+    [Theory]
+    [InlineData(USDtPaymentLinkFormat.Standard, null,
+        "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34")]
+    [InlineData(USDtPaymentLinkFormat.StandardWithoutAmount, null,
+        "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs")]
+    [InlineData(USDtPaymentLinkFormat.AddressOnly, null,
+        TronDestination)]
+    [InlineData(USDtPaymentLinkFormat.Custom, "wallet:{to}?amount={amount}&units={amountUnits}",
+        "wallet:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34&units=12340000")]
+    public void TronCheckoutReadsEveryNumericFormatWrittenByHandler(
+        USDtPaymentLinkFormat format,
+        string? template,
+        string expected)
+    {
+        var (paymentMethodId, configuration, extension) = CreateTronExtension();
+        var handler = new TronUSDtLikePaymentMethodHandler(configuration, null!, null!, null!);
+        var details = TronUSDtLikePaymentMethodHandler.CreatePaymentPromptDetails(new TronUSDtPaymentMethodConfig
+        {
+            PaymentLinkFormat = format,
+            PaymentLinkTemplate = template
+        });
+        var serializedDetails = JObject.FromObject(details, handler.Serializer);
+
+        Assert.Equal(JTokenType.Integer, serializedDetails["paymentLinkFormat"]?.Type);
+
+        var prompt = CreatePrompt(paymentMethodId, TronDestination, serializedDetails);
+        Assert.Equal(expected, extension.GetPaymentLink(prompt, null));
+    }
+
+    [Theory]
+    [InlineData(USDtPaymentLinkFormat.Standard, null,
+        "ethereum:0x1234567890123456789012345678901234567890@1/transfer?address=0x742d35cc6634c0532925a3b844bc454e4438f44e&uint256=12340000")]
+    [InlineData(USDtPaymentLinkFormat.AddressOnly, null,
+        EvmDestinationLower)]
+    [InlineData(USDtPaymentLinkFormat.Custom, "wallet:{to}?chain={chainId}&units={amountUnits}",
+        "wallet:0x742d35cc6634c0532925a3b844bc454e4438f44e?chain=1&units=12340000")]
+    public void EvmCheckoutReadsEveryNumericFormatWrittenByHandler(
+        USDtPaymentLinkFormat format,
+        string? template,
+        string expected)
+    {
+        var (paymentMethodId, configuration, extension) = CreateEvmExtension();
+        var handler = new EVMUSDtPaymentMethodHandler(configuration, null!, null!, null!);
+        var details = EVMUSDtPaymentMethodHandler.CreatePaymentPromptDetails(new EVMUSDtPaymentMethodConfig
+        {
+            PaymentLinkFormat = format,
+            PaymentLinkTemplate = template
+        });
+        var serializedDetails = JObject.FromObject(details, handler.Serializer);
+
+        Assert.Equal(JTokenType.Integer, serializedDetails["paymentLinkFormat"]?.Type);
+
+        var prompt = CreatePrompt(paymentMethodId, EvmDestination, serializedDetails);
+        Assert.Equal(expected, extension.GetPaymentLink(prompt, null));
+    }
+
+    [Theory]
+    [InlineData("Standard", "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34")]
+    [InlineData("StandardWithoutAmount", "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs")]
+    [InlineData("AddressOnly", TronDestination)]
+    [InlineData("Custom", "custom:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs")]
+    public void TronCheckoutAcceptsStringEnumRepresentations(string format, string expected)
+    {
+        var (paymentMethodId, _, extension) = CreateTronExtension();
+        var details = JObject.Parse($$"""
+                                    {
+                                      "paymentLinkFormat": "{{format}}",
+                                      "paymentLinkTemplate": "custom:{to}",
+                                      "excludeAmountFromPaymentLink": false
+                                    }
+                                    """);
+
+        var prompt = CreatePrompt(paymentMethodId, TronDestination, details);
+        Assert.Equal(expected, extension.GetPaymentLink(prompt, null));
+    }
+
+    [Theory]
+    [InlineData("Standard",
+        "ethereum:0x1234567890123456789012345678901234567890@1/transfer?address=0x742d35cc6634c0532925a3b844bc454e4438f44e&uint256=12340000")]
+    [InlineData("AddressOnly", EvmDestinationLower)]
+    [InlineData("Custom", "custom:0x742d35cc6634c0532925a3b844bc454e4438f44e")]
+    public void EvmCheckoutAcceptsStringEnumRepresentations(string format, string expected)
+    {
+        var (paymentMethodId, _, extension) = CreateEvmExtension();
+        var details = JObject.Parse($$"""
+                                    {
+                                      "paymentLinkFormat": "{{format}}",
+                                      "paymentLinkTemplate": "custom:{to}"
+                                    }
+                                    """);
+
+        var prompt = CreatePrompt(paymentMethodId, EvmDestination, details);
+        Assert.Equal(expected, extension.GetPaymentLink(prompt, null));
+    }
+
+    [Theory]
+    [InlineData(false, "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34")]
+    [InlineData(true, "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs")]
+    public void TronCheckoutPreservesLegacyInvoicesWithoutFormat(bool excludeAmount, string expected)
+    {
+        var (paymentMethodId, _, extension) = CreateTronExtension();
+        var details = JObject.FromObject(new { excludeAmountFromPaymentLink = excludeAmount });
+
+        var prompt = CreatePrompt(paymentMethodId, TronDestination, details);
+        Assert.Equal(expected, extension.GetPaymentLink(prompt, null));
+    }
+
+    [Fact]
+    public void EvmCheckoutPreservesLegacyInvoicesWithoutFormat()
+    {
+        var (paymentMethodId, _, extension) = CreateEvmExtension();
+        var prompt = CreatePrompt(paymentMethodId, EvmDestination, new JObject());
+
+        Assert.Equal(
+            "ethereum:0x1234567890123456789012345678901234567890@1/transfer?address=0x742d35cc6634c0532925a3b844bc454e4438f44e&uint256=12340000",
+            extension.GetPaymentLink(prompt, null));
+    }
+
+    [Fact]
+    public void TronCheckoutPreservesTemplateOnlyLegacyInvoices()
+    {
+        var (paymentMethodId, _, extension) = CreateTronExtension();
+        var details = JObject.Parse("""{"paymentLinkTemplate":"legacy:{to}"}""");
+
+        var prompt = CreatePrompt(paymentMethodId, TronDestination, details);
+        Assert.Equal("legacy:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs", extension.GetPaymentLink(prompt, null));
+    }
+
+    [Fact]
+    public void EvmCheckoutPreservesTemplateOnlyLegacyInvoices()
+    {
+        var (paymentMethodId, _, extension) = CreateEvmExtension();
+        var details = JObject.Parse("""{"paymentLinkTemplate":"legacy:{to}"}""");
+
+        var prompt = CreatePrompt(paymentMethodId, EvmDestination, details);
+        Assert.Equal("legacy:0x742d35cc6634c0532925a3b844bc454e4438f44e", extension.GetPaymentLink(prompt, null));
+    }
+
+    [Theory]
+    [InlineData("999")]
+    [InlineData("\"Unknown\"")]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    [InlineData("true")]
+    public void InvalidTronFormatsFallBackToStandardWithoutThrowing(string formatJson)
+    {
+        var (paymentMethodId, _, extension) = CreateTronExtension();
+        var details = JObject.Parse($$"""
+                                    {
+                                      "paymentLinkFormat": {{formatJson}},
+                                      "paymentLinkTemplate": "custom:{to}",
+                                      "excludeAmountFromPaymentLink": true
+                                    }
+                                    """);
+
+        var prompt = CreatePrompt(paymentMethodId, TronDestination, details);
+        Assert.Equal(
+            "tron:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs?amount=12.34",
+            extension.GetPaymentLink(prompt, null));
+    }
+
+    [Theory]
+    [InlineData("999")]
+    [InlineData("\"Unknown\"")]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    [InlineData("true")]
+    [InlineData("1")]
+    public void InvalidOrUnsupportedEvmFormatsFallBackToStandardWithoutThrowing(string formatJson)
+    {
+        var (paymentMethodId, _, extension) = CreateEvmExtension();
+        var details = JObject.Parse($$"""
+                                    {
+                                      "paymentLinkFormat": {{formatJson}},
+                                      "paymentLinkTemplate": "custom:{to}"
+                                    }
+                                    """);
+
+        var prompt = CreatePrompt(paymentMethodId, EvmDestination, details);
+        Assert.Equal(
+            "ethereum:0x1234567890123456789012345678901234567890@1/transfer?address=0x742d35cc6634c0532925a3b844bc454e4438f44e&uint256=12340000",
+            extension.GetPaymentLink(prompt, null));
+    }
+
+    [Fact]
+    public void NullFormatRetainsTemplateOnlyCompatibilityOnBothFamilies()
+    {
+        var details = JObject.Parse("""
+                                    {
+                                      "paymentLinkFormat": null,
+                                      "paymentLinkTemplate": "legacy:{to}"
+                                    }
+                                    """);
+
+        var (tronPaymentMethodId, _, tronExtension) = CreateTronExtension();
+        var tronPrompt = CreatePrompt(tronPaymentMethodId, TronDestination, details);
+        Assert.Equal("legacy:TG3XXyExBkPp9nzdajDZsozEu4BkaSJozs", tronExtension.GetPaymentLink(tronPrompt, null));
+
+        var (evmPaymentMethodId, _, evmExtension) = CreateEvmExtension();
+        var evmPrompt = CreatePrompt(evmPaymentMethodId, EvmDestination, details);
+        Assert.Equal("legacy:0x742d35cc6634c0532925a3b844bc454e4438f44e", evmExtension.GetPaymentLink(evmPrompt, null));
+    }
+
+    private static (PaymentMethodId PaymentMethodId, TronUSDtLikeConfigurationItem Configuration,
+        TronUSDtPaymentLinkExtension Extension) CreateTronExtension()
+    {
+        var configuration = new TronUSDtLikeConfigurationItem
+        {
+            JsonRpcUri = new Uri("https://example.com"),
+            SmartContractAddress = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            Currency = "USDt",
+            DisplayName = "USDt on TRON",
+            Divisibility = 6,
+            CryptoImagePath = "icon",
+            BlockExplorerLink = "https://example.com/tx/{0}",
+            DefaultRateRules = [],
+            CurrencyDisplayName = "USD₮"
+        };
+        var paymentMethodId = configuration.GetPaymentMethodId();
+        var pluginConfiguration = new USDtPluginConfiguration();
+        pluginConfiguration.TronUSDtLikeConfigurationItems.Add(paymentMethodId, configuration);
+        return (paymentMethodId, configuration,
+            new TronUSDtPaymentLinkExtension(paymentMethodId, pluginConfiguration));
+    }
+
+    private static (PaymentMethodId PaymentMethodId, EVMUSDtLikeConfigurationItem Configuration,
+        EVMUSDtPaymentLinkExtension Extension) CreateEvmExtension()
+    {
+        var configuration = new EVMUSDtLikeConfigurationItem("ETHEREUM")
+        {
+            JsonRpcUri = new Uri("https://example.com"),
+            SmartContractAddress = EvmContractLower,
+            Currency = "USDt",
+            DisplayName = "USDt on ETHEREUM",
+            Divisibility = 6,
+            CryptoImagePath = "icon",
+            BlockExplorerLink = "https://example.com/tx/{0}",
+            DefaultRateRules = [],
+            CurrencyDisplayName = "USD₮",
+            ChainId = 1
+        };
+        var paymentMethodId = configuration.GetPaymentMethodId();
+        var pluginConfiguration = new USDtPluginConfiguration();
+        pluginConfiguration.EVMUSDtLikeConfigurationItems.Add(paymentMethodId, configuration);
+        return (paymentMethodId, configuration,
+            new EVMUSDtPaymentLinkExtension(paymentMethodId, pluginConfiguration));
+    }
+
+    private static PaymentPrompt CreatePrompt(PaymentMethodId paymentMethodId, string destination, JToken details)
+    {
+        var invoice = new InvoiceEntity
+        {
+            Currency = "USD",
+            Price = 12.34m
+        };
+#pragma warning disable CS0618
+        invoice.Payments = [];
+        invoice.Rates["USDt"] = 1m;
+#pragma warning restore CS0618
+        var prompt = new PaymentPrompt
+        {
+            Currency = "USDt",
+            Destination = destination,
+            Divisibility = 6,
+            Details = details
+        };
+        invoice.SetPaymentPrompt(paymentMethodId, prompt);
+        invoice.UpdateTotals();
+        return prompt;
+    }
+}

--- a/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/EVMUSDtPaymentLinkExtension.cs
@@ -18,7 +18,7 @@ public class EVMUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId, USDtPl
         var configuration = pluginConfiguration.EVMUSDtLikeConfigurationItems[paymentMethodId];
         var template = prompt.Details?.Value<string?>("paymentLinkTemplate");
         var format = USDtPaymentLinkFormats.ResolveEvm(
-            prompt.Details?.Value<USDtPaymentLinkFormat?>("paymentLinkFormat"),
+            USDtPaymentLinkFormats.ReadFormat(prompt.Details, true),
             template);
         return BuildPaymentLink(
             prompt.Destination,

--- a/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/TronUSDtPaymentLinkExtension.cs
@@ -17,7 +17,7 @@ public class TronUSDtPaymentLinkExtension(PaymentMethodId paymentMethodId, USDtP
         var configuration = pluginConfiguration.TronUSDtLikeConfigurationItems[paymentMethodId];
         var template = prompt.Details?.Value<string?>("paymentLinkTemplate");
         var format = USDtPaymentLinkFormats.ResolveTron(
-            prompt.Details?.Value<USDtPaymentLinkFormat?>("paymentLinkFormat"),
+            USDtPaymentLinkFormats.ReadFormat(prompt.Details, false),
             template,
             prompt.Details?.Value<bool?>("excludeAmountFromPaymentLink") ?? false);
 

--- a/BTCPayServer.Plugins.USDt/Services/Payments/USDtPaymentLinkFormat.cs
+++ b/BTCPayServer.Plugins.USDt/Services/Payments/USDtPaymentLinkFormat.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Plugins.USDt.Services.Payments;
 
@@ -53,6 +55,32 @@ internal static class USDtPaymentLinkFormats
             return USDtPaymentLinkFormat.Custom;
 
         return USDtPaymentLinkFormat.Standard;
+    }
+
+    internal static USDtPaymentLinkFormat? ReadFormat(JToken? details, bool isEvm)
+    {
+        if (details is null)
+            return null;
+
+        if (details is not JObject detailsObject)
+            return USDtPaymentLinkFormat.Standard;
+
+        var token = detailsObject["paymentLinkFormat"];
+        if (token is null || token.Type is JTokenType.Null or JTokenType.Undefined)
+            return null;
+
+        try
+        {
+            var format = token.ToObject<USDtPaymentLinkFormat?>();
+            return format is { } explicitFormat && IsSupported(explicitFormat, isEvm)
+                ? explicitFormat
+                : USDtPaymentLinkFormat.Standard;
+        }
+        catch (Exception exception) when (exception is JsonException or ArgumentException or FormatException or
+                                          InvalidCastException or OverflowException)
+        {
+            return USDtPaymentLinkFormat.Standard;
+        }
     }
 
     internal static bool IsSupported(USDtPaymentLinkFormat format, bool isEvm)


### PR DESCRIPTION
## Summary

- deserialize snapshotted payment-link formats through Newtonsoft's enum-aware `ToObject` path
- use one defensive reader for both TRON and EVM checkout extensions
- fall back to the chain-safe Standard format for malformed, unknown, or unsupported explicit values
- preserve legacy boolean and template-only behavior when the format field is missing or null

## Root cause

Version 0.7.1 snapshots `paymentLinkFormat` into invoice prompt details as a JSON integer. Checkout read that token with `JToken.Value<USDtPaymentLinkFormat?>()`, which delegates to `Convert.ChangeType` and throws `InvalidCastException` for integer-to-enum conversion. The exception escaped checkout rendering and triggered BTCPay Server's plugin crash protection.

Both TRON and EVM used the same unsafe read.

## Compatibility

- numeric prompt details already written by 0.7.1 now deserialize correctly
- string enum representations remain accepted
- old invoices without the new field retain TRON `excludeAmountFromPaymentLink` behavior
- PR #47-style template-only invoice data remains Custom
- malformed and unsupported explicit values fall back to Standard without throwing
- preset and Custom payment-link outputs are unchanged

## Tests

Added 31 checkout-path regression cases covering:

- every TRON and EVM numeric format emitted by the handlers
- numeric serialization through the actual blob serializer
- string enum representations
- missing and null format fields
- legacy TRON boolean and template-only invoices
- unknown numeric/string values, objects, arrays, booleans, and EVM's unsupported StandardWithoutAmount value

Verification:

- focused regression tests: 31/31 passed
- complete plugin suite: 90/90 passed
- exact CI build/test sequence passed
- Release solution build passed with 0 errors

Fixes #59
