### PR TITLE
fix(tron): reduce RPC catch-up requests

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -49,6 +49,12 @@ public class FastTests : UnitTestBase
     }
 
     [Fact]
+    public void TronListenerWaitsOneBlockBeforeQueryingLogs()
+    {
+        Assert.Equal(1, TestableTronListener.GetHeadLag(CreateTronConfiguration()));
+    }
+
+    [Fact]
     public void RateLimitBackoffIsJitteredAndCapped()
     {
         Assert.Equal(USDtListenerShared.InitialRateLimitBackoffMs, 5_000);
@@ -943,6 +949,19 @@ public class FastTests : UnitTestBase
         public static long GetHeadLag(EVMUSDtLikeConfigurationItem configuration)
         {
             return new TestableEvmListener().GetHeadLagBlocks(configuration);
+        }
+    }
+
+    private sealed class TestableTronListener : TronUSDtListener
+    {
+        public TestableTronListener()
+            : base(null!, null!, null!, null!, null!, null!, null!, null!, null!)
+        {
+        }
+
+        public static long GetHeadLag(TronUSDtLikeConfigurationItem configuration)
+        {
+            return new TestableTronListener().GetHeadLagBlocks(configuration);
         }
     }
 

--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
@@ -58,6 +58,11 @@ public class TronUSDtListener(
         return USDtListenerShared.GetBlockPollingDelay(configurationItem.BlockTimeSeconds);
     }
 
+    protected override long GetHeadLagBlocks(TronUSDtLikeConfigurationItem configurationItem)
+    {
+        return 1;
+    }
+
     protected override long CreateInitialLastBlockHeight(HexBigInteger latestBlockNumber)
     {
         return (long)latestBlockNumber.Value;
@@ -72,25 +77,16 @@ public class TronUSDtListener(
         CancellationToken stoppingToken)
     {
         var web3Client = tronUSDtRpcProvider.GetWeb3Client(paymentMethodId);
-        var transferEvent = web3Client.Eth.GetEvent<TransferEventDTO>();
-
-        List<EventLog<TransferEventDTO>>? changes;
-        var tries = 0;
-        do
-        {
-            changes = await transferEvent.GetAllChangesAsync(
-                transferEvent.CreateFilterInput(new BlockParameter(block.Number), new BlockParameter(block.Number)));
-
-            if (changes != null && changes.Count != 0)
-                break;
-
-            await Task.Delay(250, stoppingToken);
-        } while (tries++ < 3);
+        var contractAddress =
+            usdtPluginConfiguration.TronUSDtLikeConfigurationItems[paymentMethodId].SmartContractAddress;
+        var transferEvent = web3Client.Eth.GetEvent<TransferEventDTO>(
+            TronUSDtAddressHelper.Base58ToHex(contractAddress));
+        var changes = await transferEvent.GetAllChangesAsync(
+            transferEvent.CreateFilterInput(new BlockParameter(block.Number), new BlockParameter(block.Number)));
 
         if (changes == null)
             throw new InvalidOperationException($"Unable to get changes {block.Number}");
 
-        var contractAddress = usdtPluginConfiguration.TronUSDtLikeConfigurationItems[paymentMethodId].SmartContractAddress;
         return changes
             .Where(t => !t.Log.Removed && TronUSDtAddressHelper.HexToBase58(t.Log.Address)
                 .Equals(contractAddress, StringComparison.InvariantCultureIgnoreCase))

--- a/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
@@ -101,13 +101,12 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
 
                 var listenerState = await LoadTrackingState(configurationItem);
                 var web3Client = rpcProvider.GetWeb3Client(paymentMethodId);
+                var latestBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync(
+                    BlockParameter.CreateLatest());
                 if (listenerState == null)
                 {
                     logger.LogInformation("No tracking state found for {Listener}, new blockchain",
                         logContext);
-
-                    var latestBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync(
-                        BlockParameter.CreateLatest());
 
                     listenerState = new EVMBasedListenerState
                     {
@@ -117,14 +116,13 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                 }
                 else
                 {
-                    var latestBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync(
-                        BlockParameter.CreateLatest());
-
                     logger.LogInformation(
                         "Tracking state for {Listener}, current={CurrentBlockNumber}, latest={LatestBlockNumber}",
                         logContext, listenerState.LastBlockHeight, latestBlockNumber);
                 }
 
+                var safeHeadLagBlocks = GetHeadLagBlocks(configurationItem);
+                var latestSafeBlockHeight = Math.Max(-1, (long)latestBlockNumber.Value - safeHeadLagBlocks);
                 while (!stoppingToken.IsCancellationRequested)
                 {
                     var invoices = (await trackedInvoiceProvider.GetTrackedInvoices(paymentMethodId, stoppingToken))
@@ -146,9 +144,11 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                     else
                     {
                         var nextBlockHeight = listenerState.LastBlockHeight + 1;
-                        var latestBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync();
-                        var safeHeadLagBlocks = GetHeadLagBlocks(configurationItem);
-                        var latestSafeBlockHeight = Math.Max(-1, (long)latestBlockNumber.Value - safeHeadLagBlocks);
+                        if (nextBlockHeight > latestSafeBlockHeight)
+                        {
+                            latestBlockNumber = await web3Client.Eth.Blocks.GetBlockNumber.SendRequestAsync();
+                            latestSafeBlockHeight = Math.Max(-1, (long)latestBlockNumber.Value - safeHeadLagBlocks);
+                        }
 
                         if (nextBlockHeight > latestSafeBlockHeight)
                         {


### PR DESCRIPTION
## Summary

- reuse the fetched safe head while catching up instead of calling `eth_blockNumber` for every historical block
- query transfer logs once per block and scope the RPC filter to the configured USDt contract
- keep TRON one block behind the reported head so logs have time to become queryable without retrying every empty result

## Why

Most TRON blocks do not contain a relevant USDt transfer. Previously, the common empty historical block caused six RPC requests: one head request, one block request, and four unfiltered log requests, plus one second of retry delay. The new common path uses one block request and one contract-filtered log request, refreshing the head only after reaching the cached safe head.

This should reduce RPC pressure and make catch-up substantially faster. It does not make a rate-limited public Trial endpoint suitable for production; a private node or dedicated RPC provider is still recommended.

## Tests

- `dotnet build --no-restore -p:StaticWebAssetsEnabled=false -m:1`
- `dotnet test --no-build --no-restore --verbosity minimal --settings BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.runsettings BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.csproj` (91 passed)
- `git diff --check`

Relates to #58
