### PR TITLE
fix(tron): pace RPC requests while catching up

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -55,6 +55,80 @@ public class FastTests : UnitTestBase
     }
 
     [Fact]
+    public void TronListenerPacesCatchUp()
+    {
+        Assert.Equal(
+            TimeSpan.FromMilliseconds(300),
+            TestableTronListener.GetCatchUpDelay(CreateTronConfiguration()));
+    }
+
+    [Fact]
+    public void TronListenerKeepsConfiguredHeadPollingDelay()
+    {
+        Assert.Equal(
+            TimeSpan.FromSeconds(3),
+            TestableTronListener.GetPollingDelay(CreateTronConfiguration()));
+    }
+
+    [Fact]
+    public void EvmListenersDoNotPaceCatchUp()
+    {
+        Assert.Equal(TimeSpan.Zero, TestableEvmListener.GetCatchUpDelay(CreateEvmConfiguration()));
+    }
+
+    [Fact]
+    public async Task TronCatchUpPacingIsCancellationAware()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var pacingTask = TestableTronListener.PaceCatchUp(
+            true,
+            99,
+            100,
+            CreateTronConfiguration(),
+            cancellation.Token);
+
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pacingTask);
+    }
+
+    [Fact]
+    public async Task TronCatchUpPacingCompletesImmediatelyAtSafeHead()
+    {
+        var pacingTask = TestableTronListener.PaceCatchUp(
+            true,
+            100,
+            100,
+            CreateTronConfiguration(),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(pacingTask.IsCompletedSuccessfully);
+        await pacingTask;
+    }
+
+    [Theory]
+    [InlineData(true, 99, 100, 300, true)]
+    [InlineData(true, 100, 100, 300, false)]
+    [InlineData(true, 101, 100, 300, false)]
+    [InlineData(false, 99, 100, 300, false)]
+    [InlineData(true, 99, 100, 0, false)]
+    public void CatchUpPacingRequiresASuccessfullyIndexedBackloggedBlock(
+        bool blockIndexed,
+        long lastBlockHeight,
+        long latestSafeBlockHeight,
+        int delayMilliseconds,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            USDtListenerShared.ShouldPaceCatchUpBlock(
+                blockIndexed,
+                lastBlockHeight,
+                latestSafeBlockHeight,
+                TimeSpan.FromMilliseconds(delayMilliseconds)));
+    }
+
+    [Fact]
     public void RateLimitBackoffIsJitteredAndCapped()
     {
         Assert.Equal(USDtListenerShared.InitialRateLimitBackoffMs, 5_000);
@@ -950,6 +1024,11 @@ public class FastTests : UnitTestBase
         {
             return new TestableEvmListener().GetHeadLagBlocks(configuration);
         }
+
+        public static TimeSpan GetCatchUpDelay(EVMUSDtLikeConfigurationItem configuration)
+        {
+            return new TestableEvmListener().GetCatchUpPacingDelay(configuration);
+        }
     }
 
     private sealed class TestableTronListener : TronUSDtListener
@@ -962,6 +1041,31 @@ public class FastTests : UnitTestBase
         public static long GetHeadLag(TronUSDtLikeConfigurationItem configuration)
         {
             return new TestableTronListener().GetHeadLagBlocks(configuration);
+        }
+
+        public static TimeSpan GetCatchUpDelay(TronUSDtLikeConfigurationItem configuration)
+        {
+            return new TestableTronListener().GetCatchUpPacingDelay(configuration);
+        }
+
+        public static Task PaceCatchUp(
+            bool blockIndexed,
+            BigInteger lastBlockHeight,
+            BigInteger latestSafeBlockHeight,
+            TronUSDtLikeConfigurationItem configuration,
+            CancellationToken cancellationToken)
+        {
+            return new TestableTronListener().PaceCatchUpAsync(
+                blockIndexed,
+                lastBlockHeight,
+                latestSafeBlockHeight,
+                configuration,
+                cancellationToken);
+        }
+
+        public static TimeSpan GetPollingDelay(TronUSDtLikeConfigurationItem configuration)
+        {
+            return new TestableTronListener().GetHeadPollingDelay(configuration);
         }
     }
 

--- a/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/TronUSDtListener.cs
@@ -39,6 +39,10 @@ public class TronUSDtListener(
         handlers,
         paymentService)
 {
+    // Backlog scanning uses two RPC calls per block. This caps that work near 7 QPS before network latency,
+    // leaving headroom under TronGrid's 15 QPS key limit for head and balance requests.
+    private static readonly TimeSpan CatchUpPacingDelay = TimeSpan.FromMilliseconds(300);
+
     protected override IReadOnlyDictionary<PaymentMethodId, TronUSDtLikeConfigurationItem> GetConfigurations()
     {
         return usdtPluginConfiguration.TronUSDtLikeConfigurationItems;
@@ -56,6 +60,11 @@ public class TronUSDtListener(
     protected override TimeSpan GetHeadPollingDelay(TronUSDtLikeConfigurationItem configurationItem)
     {
         return USDtListenerShared.GetBlockPollingDelay(configurationItem.BlockTimeSeconds);
+    }
+
+    protected override TimeSpan GetCatchUpPacingDelay(TronUSDtLikeConfigurationItem configurationItem)
+    {
+        return CatchUpPacingDelay;
     }
 
     protected override long GetHeadLagBlocks(TronUSDtLikeConfigurationItem configurationItem)

--- a/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListener.cs
@@ -55,6 +55,22 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
     protected virtual long CreateInitialLastBlockHeight(HexBigInteger latestBlockNumber) => (long)latestBlockNumber.Value - 1;
     protected virtual long GetHeadLagBlocks(TConfigurationItem configurationItem) => 0;
     protected virtual TimeSpan GetHeadPollingDelay(TConfigurationItem configurationItem) => TimeSpan.FromSeconds(1);
+    protected virtual TimeSpan GetCatchUpPacingDelay(TConfigurationItem configurationItem) => TimeSpan.Zero;
+    protected async Task PaceCatchUpAsync(
+        bool blockIndexed,
+        BigInteger lastBlockHeight,
+        BigInteger latestSafeBlockHeight,
+        TConfigurationItem configurationItem,
+        CancellationToken cancellationToken)
+    {
+        var delay = GetCatchUpPacingDelay(configurationItem);
+        if (USDtListenerShared.ShouldPaceCatchUpBlock(
+                blockIndexed,
+                lastBlockHeight,
+                latestSafeBlockHeight,
+                delay))
+            await Task.Delay(delay, cancellationToken);
+    }
     protected virtual LogLevel EmptyQueueBlockAdvanceLogLevel => LogLevel.Information;
     protected virtual IDisposable? BeginLoggingScope(PaymentMethodId paymentMethodId) => null;
     protected virtual string NormalizeDestinationKey(string destination) => destination.ToLowerInvariant();
@@ -125,6 +141,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                 var latestSafeBlockHeight = Math.Max(-1, (long)latestBlockNumber.Value - safeHeadLagBlocks);
                 while (!stoppingToken.IsCancellationRequested)
                 {
+                    var blockIndexed = false;
                     var invoices = (await trackedInvoiceProvider.GetTrackedInvoices(paymentMethodId, stoppingToken))
                         .Where(invoice => invoice.GetPaymentPrompt(paymentMethodId)?.Activated is true)
                         .ToArray();
@@ -170,6 +187,7 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
                                 logContext, block.Number);
 
                             listenerState.LastBlockHeight = (long)block.Number.Value;
+                            blockIndexed = true;
                         }
                         else
                         {
@@ -182,6 +200,12 @@ public abstract class USDtListener<TConfigurationItem, TPaymentData>(
 
                     await SetTrackingState(configurationItem, listenerState);
                     rateLimitBackoffMs = USDtListenerShared.InitialRateLimitBackoffMs;
+                    await PaceCatchUpAsync(
+                        blockIndexed,
+                        listenerState.LastBlockHeight,
+                        latestSafeBlockHeight,
+                        configurationItem,
+                        stoppingToken);
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/BTCPayServer.Plugins.USDt/Services/USDtListenerShared.cs
+++ b/BTCPayServer.Plugins.USDt/Services/USDtListenerShared.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using BTCPayServer.Client.Models;
 using Nethereum.Hex.HexTypes;
 
@@ -19,6 +20,17 @@ public static class USDtListenerShared
     internal static TimeSpan GetBlockPollingDelay(double blockTimeSeconds)
     {
         return TimeSpan.FromSeconds(Math.Max(1, blockTimeSeconds));
+    }
+
+    internal static bool ShouldPaceCatchUpBlock(
+        bool blockIndexed,
+        BigInteger lastBlockHeight,
+        BigInteger latestSafeBlockHeight,
+        TimeSpan delay)
+    {
+        return blockIndexed &&
+               lastBlockHeight < latestSafeBlockHeight &&
+               delay > TimeSpan.Zero;
     }
 
     internal static int CalculateRateLimitDelayMs(int backoffMs, double jitterUnit)


### PR DESCRIPTION
Summary
- wait 300 ms between successfully persisted TRON backlog blocks
- keep head polling, empty-queue advancement, EVM listeners, and payment matching unchanged
- preserve the existing exponential rate-limit backoff as a fallback

Why
Each TRON backlog block currently performs a block request followed by a log request with no pacing. TronGrid enforces a 15 QPS key limit, so fast RPC responses can trigger frequency-limit errors and exponential sleeps even when the daily quota is not exhausted. The delay caps catch-up scanning near 7 QPS before network latency while leaving headroom for head and balance calls. It deliberately does not reduce the total daily request count.

Tests
- full plugin test suite: 101 passed, 0 failed
- new coverage for TRON-only configuration, EVM default behavior, backlog eligibility, safe-head behavior, and cancellation