### PR TITLE
fix: retain multiple ERC-20 transfers per transaction

### DIFF
--- a/BTCPayServer.Plugins.USDt.Tests/Erc20RegressionTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/Erc20RegressionTests.cs
@@ -115,4 +115,61 @@ public class Erc20RegressionTests
         Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots(
             [log, log with { Value = 2 }], [destination]));
     }
+
+    [Theory]
+    [InlineData("ABC-3")]
+    [InlineData("ABC-3-LOG-7")]
+    public void ReplayPreservesExactStoredIdDespiteCasing(string storedId)
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        var replay = EVMUSDtListener.ToTransferMatchSnapshots([log], [destination],
+            [new EVMUSDtListener.ExistingTransferSnapshot(storedId, destination, 1)]);
+        Assert.Equal(storedId, Assert.Single(replay).TransactionId);
+    }
+
+    [Fact]
+    public void IdenticalStoredEntriesAreDeduplicated()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        var stored = new EVMUSDtListener.ExistingTransferSnapshot("abc-3", destination, 1);
+        var replay = EVMUSDtListener.ToTransferMatchSnapshots([log], [destination], [stored, stored]);
+        Assert.Equal(stored.TransactionId, Assert.Single(replay).TransactionId);
+    }
+
+    [Theory]
+    [InlineData("abc-3", 2)]
+    [InlineData("ABC-3", 1)]
+    public void ConflictingStoredEntriesFailWithPaymentId(string secondId, int secondAmount)
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        var error = Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots([log], [destination],
+            [new EVMUSDtListener.ExistingTransferSnapshot("abc-3", destination, 1),
+             new EVMUSDtListener.ExistingTransferSnapshot(secondId, destination, secondAmount)]));
+        Assert.Contains(secondId, error.Message);
+    }
+
+    [Fact]
+    public void RpcHashCasingDoesNotChangeNewIdsOrDuplicateLogs()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        var initial = Assert.Single(EVMUSDtListener.ToTransferMatchSnapshots([log], [destination]));
+        var replay = EVMUSDtListener.ToTransferMatchSnapshots([log, log with { TransactionHash = "0XABC" }], [destination]);
+        Assert.Equal(initial, Assert.Single(replay));
+    }
+
+    [Theory]
+    [InlineData("ABC-3")]
+    [InlineData("ABC-3-LOG-7")]
+    public void StoredMismatchReportsExactPaymentId(string storedId)
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        var error = Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots([log], [destination],
+            [new EVMUSDtListener.ExistingTransferSnapshot(storedId, destination, 2)]));
+        Assert.Contains(storedId, error.Message);
+    }
 }

--- a/BTCPayServer.Plugins.USDt.Tests/Erc20RegressionTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/Erc20RegressionTests.cs
@@ -24,7 +24,7 @@ public class Erc20RegressionTests
     }
 
     [Fact]
-    public void BatchTransfersKeepLegacyIdAndCreditEachAdditionalLogExactlyOnce()
+    public void BatchTransfersCreditEachLogExactlyOnceWithStableIds()
     {
         const string destination = "0x1111111111111111111111111111111111111111";
         var first = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1_000_000, "0xabc", "3", false, 7);
@@ -32,7 +32,7 @@ public class Erc20RegressionTests
         var result = EVMUSDtListener.ToTransferMatchSnapshots([second, first, first, second], [destination]);
         Assert.Equal(2, result.Count);
         Assert.Equal(new BigInteger(3_000_000), result.Aggregate(BigInteger.Zero, (sum, transfer) => sum + transfer.TotalAmount));
-        Assert.Contains(result, m => m.TransactionId == "abc-3");
+        Assert.Contains(result, m => m.TransactionId == "abc-3-log-7");
         Assert.Contains(result, m => m.TransactionId == "abc-3-log-8");
         Assert.Equal(result, EVMUSDtListener.ToTransferMatchSnapshots([first, second], [destination]));
     }
@@ -56,5 +56,63 @@ public class Erc20RegressionTests
         var transfer = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
         Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots([transfer], [destination],
             [new EVMUSDtListener.ExistingTransferSnapshot("abc-3", destination, 2)]));
+    }
+
+    [Fact]
+    public void RemovingTrackedDestinationDoesNotRenameRemainingTransfer()
+    {
+        const string firstDestination = "0x1111111111111111111111111111111111111111";
+        const string secondDestination = "0x2222222222222222222222222222222222222222";
+        var first = new EVMUSDtListener.TransferLogSnapshot(firstDestination, firstDestination, 1_000_000, "0xabc", "3", false, 7);
+        var second = first with { To = secondDestination, LogIndex = 8 };
+        var initial = EVMUSDtListener.ToTransferMatchSnapshots([first, second], [firstDestination, secondDestination]);
+        var remaining = initial.Single(match => match.To == secondDestination);
+        var replay = EVMUSDtListener.ToTransferMatchSnapshots([second], [secondDestination],
+            [new EVMUSDtListener.ExistingTransferSnapshot(remaining.TransactionId, remaining.To, remaining.TotalAmount)]);
+        Assert.Equal(remaining, Assert.Single(replay));
+    }
+
+    [Fact]
+    public void AddingTrackedDestinationDoesNotRenamePreviouslySeenTransfer()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var first = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1_000_000, "0xabc", "3", false, 7);
+        var second = first with { To = "0x2222222222222222222222222222222222222222", LogIndex = 8 };
+        var initial = Assert.Single(EVMUSDtListener.ToTransferMatchSnapshots([second], [second.To]));
+        var replay = EVMUSDtListener.ToTransferMatchSnapshots([first, second], [first.To, second.To],
+            [new EVMUSDtListener.ExistingTransferSnapshot(initial.TransactionId, initial.To, initial.TotalAmount)]);
+        Assert.Equal(initial, replay.Single(match => match.To == second.To));
+    }
+
+    [Fact]
+    public void EqualAmountLegacyReplayDoesNotStealAnAlreadyIndexedLog()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var first = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1_000_000, "0xabc", "3", false, 7);
+        var second = first with { LogIndex = 8 };
+        var result = EVMUSDtListener.ToTransferMatchSnapshots([first, second], [destination],
+            [new EVMUSDtListener.ExistingTransferSnapshot("abc-3", destination, 1_000_000),
+             new EVMUSDtListener.ExistingTransferSnapshot("abc-3-log-7", destination, 1_000_000)]);
+        Assert.Equal(new[] { "abc-3-log-7", "abc-3" }, result.Select(match => match.TransactionId));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(-1)]
+    public void MissingOrNegativeLogIndexFailsClosed(int? index)
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false,
+            index.HasValue ? new BigInteger(index.Value) : null);
+        Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots([log], [destination]));
+    }
+
+    [Fact]
+    public void ConflictingDuplicateLogFailsClosed()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var log = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots(
+            [log, log with { Value = 2 }], [destination]));
     }
 }

--- a/BTCPayServer.Plugins.USDt.Tests/Erc20RegressionTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/Erc20RegressionTests.cs
@@ -1,0 +1,60 @@
+using System.Numerics;
+using BTCPayServer.Plugins.USDt.Configuration;
+using BTCPayServer.Plugins.USDt.Services;
+using Microsoft.Extensions.Configuration;
+using NBitcoin;
+using NBXplorer;
+using Xunit;
+
+namespace BTCPayServer.Plugins.USDt.Tests;
+
+public class Erc20RegressionTests
+{
+    [Fact]
+    public void EthereumUsdtIsAlreadyRegisteredWithCanonicalContractAndSixDecimals()
+    {
+        var configs = USDtConfigurationProvider.GetEVMUSDtLikeDefaultConfigurationItems(
+            new NBXplorerNetworkProvider(ChainName.Mainnet), new ConfigurationBuilder().Build());
+        var eth = configs.Values.Single(c => c.ChainId == 1);
+        Assert.Equal("USDT-ETHEREUM", eth.GetPaymentMethodId().ToString());
+        Assert.Equal("0xdac17f958d2ee523a2206206994597c13d831ec7", eth.SmartContractAddress);
+        Assert.Equal(6, eth.Divisibility);
+        Assert.Contains(configs.Values, c => c.ChainId == 137);
+        Assert.Contains(configs.Values, c => c.ChainId == 56);
+    }
+
+    [Fact]
+    public void BatchTransfersKeepLegacyIdAndCreditEachAdditionalLogExactlyOnce()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var first = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1_000_000, "0xabc", "3", false, 7);
+        var second = first with { Value = 2_000_000, LogIndex = 8 };
+        var result = EVMUSDtListener.ToTransferMatchSnapshots([second, first, first, second], [destination]);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new BigInteger(3_000_000), result.Aggregate(BigInteger.Zero, (sum, transfer) => sum + transfer.TotalAmount));
+        Assert.Contains(result, m => m.TransactionId == "abc-3");
+        Assert.Contains(result, m => m.TransactionId == "abc-3-log-8");
+        Assert.Equal(result, EVMUSDtListener.ToTransferMatchSnapshots([first, second], [destination]));
+    }
+
+    [Fact]
+    public void RescanKeepsPreviouslyCreditedTransferEvenWhenRpcBatchOrderChanges()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var first = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1_000_000, "0xabc", "3", false, 7);
+        var second = first with { Value = 2_000_000, LogIndex = 8 };
+        var result = EVMUSDtListener.ToTransferMatchSnapshots([first, second], [destination],
+            [new EVMUSDtListener.ExistingTransferSnapshot("abc-3", destination, 2_000_000)]);
+        Assert.Equal(new BigInteger(2_000_000), result.Single(m => m.TransactionId == "abc-3").TotalAmount);
+        Assert.Equal(new BigInteger(1_000_000), result.Single(m => m.TransactionId == "abc-3-log-7").TotalAmount);
+    }
+
+    [Fact]
+    public void MismatchedHistoricalPaymentFailsClosed()
+    {
+        const string destination = "0x1111111111111111111111111111111111111111";
+        var transfer = new EVMUSDtListener.TransferLogSnapshot(destination, destination, 1, "0xabc", "3", false, 7);
+        Assert.Throws<InvalidOperationException>(() => EVMUSDtListener.ToTransferMatchSnapshots([transfer], [destination],
+            [new EVMUSDtListener.ExistingTransferSnapshot("abc-3", destination, 2)]));
+    }
+}

--- a/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
+++ b/BTCPayServer.Plugins.USDt.Tests/FastTests.cs
@@ -874,21 +874,21 @@ public class FastTests : UnitTestBase
                     123,
                     "0xabc",
                     "1",
-                    false),
+                    false, 0),
                 new EVMUSDtListener.TransferLogSnapshot(
                     "0x9999999999999999999999999999999999999999",
                     "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                     456,
                     "0xdef",
                     "2",
-                    false),
+                    false, 1),
                 new EVMUSDtListener.TransferLogSnapshot(
                     "0x1111111111111111111111111111111111111111",
                     "0xcccccccccccccccccccccccccccccccccccccccc",
                     789,
                     "0xghi",
                     "3",
-                    true)
+                    true, 2)
             ],
             trackedAddresses);
 
@@ -897,7 +897,7 @@ public class FastTests : UnitTestBase
         Assert.Equal("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", match.From);
         Assert.Equal("0x742D35Cc6634C0532925a3b844Bc454e4438f44E", match.To);
         Assert.Equal(new BigInteger(123), match.TotalAmount);
-        Assert.Equal("abc-1", match.TransactionId);
+        Assert.Equal("abc-1-log-0", match.TransactionId);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
@@ -173,21 +173,26 @@ public class EVMUSDtListener(
             .ToHashSet(StringComparer.Ordinal);
 
         var existing = (existingTransfers ?? []).ToDictionary(payment => payment.TransactionId);
-        // Match the stored recipient and amount: old RPC batches could return logs
-        // in a different order. Never assign an already credited log a new ID.
+        // New IDs must not depend on which invoice destinations remain tracked.
+        // Only reuse a legacy ID when it is already stored for a matching log.
         return changes
             .Where(change => !change.Removed)
             .OrderBy(change => change.LogIndex)
             .GroupBy(change => change.TransactionHash)
             .SelectMany(group =>
             {
-                var logs = group.DistinctBy(change => change.LogIndex ?? -1).ToArray();
+                if (group.Any(change => change.LogIndex is null || change.LogIndex < 0))
+                    throw new InvalidOperationException("ERC-20 transfer log has no valid log index.");
+                var logs = group.DistinctBy(change => change.LogIndex).ToArray();
+                if (group.Any(change => change != logs.Single(log => log.LogIndex == change.LogIndex)))
+                    throw new InvalidOperationException("Conflicting ERC-20 transfer logs have the same log index.");
                 var legacyId = $"{logs[0].TransactionHash.Replace("0x", "")}-{logs[0].TransactionIndex}";
-                var legacyIndex = 0;
+                var legacyIndex = -1;
                 if (existing.TryGetValue(legacyId, out var previous))
                 {
                     legacyIndex = Array.FindIndex(logs, log =>
-                        string.Equals(log.To, previous.To, StringComparison.OrdinalIgnoreCase) && log.Value == previous.Value);
+                        string.Equals(log.To, previous.To, StringComparison.OrdinalIgnoreCase) && log.Value == previous.Value &&
+                        !existing.ContainsKey($"{legacyId}-log-{log.LogIndex}"));
                     if (legacyIndex < 0)
                         throw new InvalidOperationException("Stored ERC-20 payment does not match the returned transfer logs.");
                 }

--- a/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
@@ -128,8 +128,17 @@ public class EVMUSDtListener(
                     change.Event.Value,
                     change.Log.TransactionHash,
                     change.Log.TransactionIndex?.ToString() ?? string.Empty,
-                    change.Log.Removed)),
-                invoicesPerAddress.Keys)
+                    change.Log.Removed,
+                    change.Log.LogIndex?.Value)),
+                invoicesPerAddress.Keys,
+                invoicesPerAddress.Values.SelectMany(invoice => invoice.GetPayments(false))
+                    .Where(payment => payment.PaymentMethodId == paymentMethodId)
+                    .Select(payment =>
+                    {
+                        var details = (EVMUSDtPaymentData)handlers[paymentMethodId].ParsePaymentDetails(payment.Details);
+                        return new ExistingTransferSnapshot(details.TransactionId, details.To,
+                            Nethereum.Web3.Web3.Convert.ToWei(payment.Value, configuration.Divisibility));
+                    }))
             .Select(match => new USDtTransferMatch(
                 match.DestinationKey,
                 match.From,
@@ -155,21 +164,37 @@ public class EVMUSDtListener(
 
     internal static IReadOnlyCollection<TransferMatchSnapshot> ToTransferMatchSnapshots(
         IEnumerable<TransferLogSnapshot> changes,
-        IEnumerable<string> destinationKeys)
+        IEnumerable<string> destinationKeys,
+        IEnumerable<ExistingTransferSnapshot>? existingTransfers = null)
     {
         var destinationKeySet = destinationKeys
             .Where(address => !string.IsNullOrWhiteSpace(address))
             .Select(address => address.ToLowerInvariant())
             .ToHashSet(StringComparer.Ordinal);
 
+        var existing = (existingTransfers ?? []).ToDictionary(payment => payment.TransactionId);
+        // Match the stored recipient and amount: old RPC batches could return logs
+        // in a different order. Never assign an already credited log a new ID.
         return changes
             .Where(change => !change.Removed)
-            .Select(change => new TransferMatchSnapshot(
-                change.To.ToLowerInvariant(),
-                change.From,
-                change.To,
-                change.Value,
-                $"{change.TransactionHash.Replace("0x", "")}-{change.TransactionIndex}"))
+            .OrderBy(change => change.LogIndex)
+            .GroupBy(change => change.TransactionHash)
+            .SelectMany(group =>
+            {
+                var logs = group.DistinctBy(change => change.LogIndex ?? -1).ToArray();
+                var legacyId = $"{logs[0].TransactionHash.Replace("0x", "")}-{logs[0].TransactionIndex}";
+                var legacyIndex = 0;
+                if (existing.TryGetValue(legacyId, out var previous))
+                {
+                    legacyIndex = Array.FindIndex(logs, log =>
+                        string.Equals(log.To, previous.To, StringComparison.OrdinalIgnoreCase) && log.Value == previous.Value);
+                    if (legacyIndex < 0)
+                        throw new InvalidOperationException("Stored ERC-20 payment does not match the returned transfer logs.");
+                }
+                return logs.Select((change, index) => new TransferMatchSnapshot(
+                    change.To.ToLowerInvariant(), change.From, change.To, change.Value,
+                    index == legacyIndex ? legacyId : $"{legacyId}-log-{change.LogIndex}"));
+            })
             .Where(match => destinationKeySet.Contains(match.DestinationKey))
             .DistinctBy(match => match.TransactionId)
             .ToArray();
@@ -188,7 +213,10 @@ public class EVMUSDtListener(
         BigInteger Value,
         string TransactionHash,
         string TransactionIndex,
-        bool Removed);
+        bool Removed,
+        BigInteger? LogIndex = null);
+
+    internal sealed record ExistingTransferSnapshot(string TransactionId, string To, BigInteger Value);
 
     internal sealed record TransferMatchSnapshot(
         string DestinationKey,

--- a/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
+++ b/BTCPayServer.Plugins.USDt/Services/EVMUSDtListener.cs
@@ -172,11 +172,25 @@ public class EVMUSDtListener(
             .Select(address => address.ToLowerInvariant())
             .ToHashSet(StringComparer.Ordinal);
 
-        var existing = (existingTransfers ?? []).ToDictionary(payment => payment.TransactionId);
+        var existing = new Dictionary<string, ExistingTransferSnapshot>(StringComparer.OrdinalIgnoreCase);
+        foreach (var payment in existingTransfers ?? [])
+        {
+            if (existing.TryGetValue(payment.TransactionId, out var duplicate))
+            {
+                // Identical repeated entries are harmless, but two distinct stored IDs
+                // differing only in case cannot safely be treated as one DB payment.
+                if (duplicate.TransactionId != payment.TransactionId || duplicate.Value != payment.Value ||
+                    !string.Equals(duplicate.To, payment.To, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException($"Conflicting stored ERC-20 payment ID: {payment.TransactionId}.");
+            }
+            else
+                existing.Add(payment.TransactionId, payment);
+        }
         // New IDs must not depend on which invoice destinations remain tracked.
         // Only reuse a legacy ID when it is already stored for a matching log.
         return changes
             .Where(change => !change.Removed)
+            .Select(change => change with { TransactionHash = change.TransactionHash.ToLowerInvariant() })
             .OrderBy(change => change.LogIndex)
             .GroupBy(change => change.TransactionHash)
             .SelectMany(group =>
@@ -194,11 +208,19 @@ public class EVMUSDtListener(
                         string.Equals(log.To, previous.To, StringComparison.OrdinalIgnoreCase) && log.Value == previous.Value &&
                         !existing.ContainsKey($"{legacyId}-log-{log.LogIndex}"));
                     if (legacyIndex < 0)
-                        throw new InvalidOperationException("Stored ERC-20 payment does not match the returned transfer logs.");
+                        throw new InvalidOperationException($"Stored ERC-20 payment {previous.TransactionId} does not match the returned transfer logs.");
                 }
-                return logs.Select((change, index) => new TransferMatchSnapshot(
-                    change.To.ToLowerInvariant(), change.From, change.To, change.Value,
-                    index == legacyIndex ? legacyId : $"{legacyId}-log-{change.LogIndex}"));
+                return logs.Select((change, index) =>
+                {
+                    var id = index == legacyIndex ? previous!.TransactionId : $"{legacyId}-log-{change.LogIndex}";
+                    if (existing.TryGetValue(id, out var stored))
+                    {
+                        if (stored.Value != change.Value || !string.Equals(stored.To, change.To, StringComparison.OrdinalIgnoreCase))
+                            throw new InvalidOperationException($"Stored ERC-20 payment {stored.TransactionId} does not match the returned transfer log.");
+                        id = stored.TransactionId;
+                    }
+                    return new TransferMatchSnapshot(change.To.ToLowerInvariant(), change.From, change.To, change.Value, id);
+                });
             })
             .Where(match => destinationKeySet.Contains(match.DestinationKey))
             .DistinctBy(match => match.TransactionId)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Multiple Transfer events in one transaction are credited separately. New
 transfers use a log-index suffix, keeping their identities stable even when the
 set of tracked destinations changes. Already stored legacy IDs are retained by
 matching the recipient and amount to a log not credited under a log-index ID.
+Replay matching ignores ID casing but preserves the exact stored ID. Identical
+repeated stored entries are tolerated; conflicting entries (including distinct
+stored IDs differing only in case) require reconciliation and stop processing.
 Missing/invalid indices, conflicting duplicates, and unmatched legacy payments
 stop processing rather than risk incorrect credit. Existing stored payments are
 not rewritten; previously missed historical logs require an explicit rescan.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ Install the plugin from the BTCPay Server > Settings > Plugin > Available Plugin
 Ethereum USDt is already supported as `USDT-ETHEREUM`, using the six-decimal
 contract `0xdac17f958d2ee523a2206206994597c13d831ec7` on chain ID 1.
 The EVM listener queries ERC-20 Transfer logs and tracks confirmation counts.
-Multiple Transfer events in one transaction are credited separately. The first
-transfer retains the legacy payment ID; additional transfers use a log-index
-suffix so they are not discarded as duplicates. Existing stored payments are
+Multiple Transfer events in one transaction are credited separately. New
+transfers use a log-index suffix, keeping their identities stable even when the
+set of tracked destinations changes. Already stored legacy IDs are retained by
+matching the recipient and amount to a log not credited under a log-index ID.
+Missing/invalid indices, conflicting duplicates, and unmatched legacy payments
+stop processing rather than risk incorrect credit. Existing stored payments are
 not rewritten; previously missed historical logs require an explicit rescan.
 
 ### Naming convention

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ USDt invoice destinations remain reserved and monitored after invoice expiration
 Install the plugin from the BTCPay Server > Settings > Plugin > Available Plugins, and restart.
 
 ## 🧑‍💻 Developing
+### Ethereum ERC-20 support
+
+Ethereum USDt is already supported as `USDT-ETHEREUM`, using the six-decimal
+contract `0xdac17f958d2ee523a2206206994597c13d831ec7` on chain ID 1.
+The EVM listener queries ERC-20 Transfer logs and tracks confirmation counts.
+Multiple Transfer events in one transaction are credited separately. The first
+transfer retains the legacy payment ID; additional transfers use a log-index
+suffix so they are not discarded as duplicates. Existing stored payments are
+not rewritten; previously missed historical logs require an explicit rescan.
+
 ### Naming convention
 This plugin aims to cover USDt payment over different chains, a rigorous naming convention was implemented to ensure readability but also allow extensibility:
 


### PR DESCRIPTION
Ethereum USDt is already supported, but the listener identified transfers by transaction hash and transaction index. A transaction containing multiple ERC-20 Transfer events therefore credited only one event.

Give every new event a log-index identity that remains stable as the set of tracked invoice destinations changes. Preserve already stored legacy IDs by matching recipient and amount while excluding logs already credited under a log-index ID. This also prevents equal-amount replay from assigning a credited log another identity. Reject missing/negative log indices, conflicting duplicate logs, and unmatched historical payments rather than risk incorrect credit. Existing historical payments are not rewritten and previously missed logs are not automatically rescanned.

Replay lookup is case-insensitive and preserves the exact stored payment ID, including log-index IDs. Identical repeated stored entries are deduplicated. Conflicting amounts/recipients or distinct stored IDs differing only in case fail closed with the affected ID in the error; silently picking a record would conceal ambiguous payment accounting. RPC transaction hashes are normalized for new identities. This addresses Copilot's remaining casing/duplicate feedback; its README wording and missing-index concerns are also covered.

Validation: all 109 plugin tests pass with zero skips (91 baseline plus 18 regression cases). Coverage includes canonical Ethereum USDT configuration, multiple logs and duplicate replay, changed historical batch order, tracked destinations being added/removed, equal-amount historical replay, invalid indices, conflicting duplicates, mixed-case stored IDs and RPC hashes, identical/conflicting stored entries, and mismatched historical payment refusal with diagnostic IDs. The destination-removal and equal-amount regression tests were also run against the earlier PR implementation and reproduced both failures before the fix. Existing TRON, Polygon/BSC configuration, checkout, expiration tracking, and activation tests remain passing. `git diff --check` passes.

Test command: `dotnet test BTCPayServer.Plugins.USDt.Tests/BTCPayServer.Plugins.USDt.Tests.csproj -c Release -m:1 -p:StaticWebAssetsEnabled=false`

No live transactions, deployment, or historical rescans were performed. Existing NuGet advisories in the pinned BTCPay dependency graph remain. This draft is separate from the new standalone USDC plugin work.
